### PR TITLE
Fix auto-create when daily folder missing

### DIFF
--- a/main.js
+++ b/main.js
@@ -137,7 +137,14 @@ var DDSuggest = class extends import_obsidian.EditorSuggest {
       end
     );
     if (settings.autoCreate && !this.app.vault.getAbstractFileByPath(linkPath + ".md")) {
-      this.app.vault.create(linkPath + ".md", "");
+      const target = linkPath + ".md";
+      const folder = settings.dailyFolder.trim();
+      (async () => {
+        if (folder && !this.app.vault.getAbstractFileByPath(folder)) {
+          await this.app.vault.createFolder(folder);
+        }
+        await this.app.vault.create(target, "");
+      })();
     }
     this.close();
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -201,12 +201,22 @@ class DDSuggest extends EditorSuggest<string> {
 		/* ----------------------------------------------------------------
 		   4. Optional auto-create note
 		----------------------------------------------------------------- */
-		if (
-			settings.autoCreate &&
-			!this.app.vault.getAbstractFileByPath(linkPath + ".md")
-		) {
-			this.app.vault.create(linkPath + ".md", "");
-		}
+                if (
+                        settings.autoCreate &&
+                        !this.app.vault.getAbstractFileByPath(linkPath + ".md")
+                ) {
+                        const target = linkPath + ".md";
+                        const folder = settings.dailyFolder.trim();
+                        (async () => {
+                                if (
+                                        folder &&
+                                        !this.app.vault.getAbstractFileByPath(folder)
+                                ) {
+                                        await this.app.vault.createFolder(folder);
+                                }
+                                await this.app.vault.create(target, "");
+                        })();
+                }
 	
 		this.close();
 	}


### PR DESCRIPTION
## Summary
- ensure daily note folder is created before creating new notes

## Testing
- `npx tsc` *(fails: Cannot find type definition file for 'obsidian')*