### PR TITLE
Improve natural language parsing

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,6 @@ interface DDSettings {
         autoCreate: boolean;
         keepAliasWithShift: boolean;
         aliasFormat: "capitalize" | "keep" | "date";
-        template: string;
         openOnCreate: boolean;
 }
 
@@ -32,7 +31,6 @@ const DEFAULT_SETTINGS: DDSettings = {
         autoCreate: false,
         keepAliasWithShift: true,
         aliasFormat: "capitalize",
-        template: "",
         openOnCreate: false,
 };
 
@@ -67,7 +65,6 @@ const PHRASES = BASE_WORDS.flatMap((w) =>
         WEEKDAYS.includes(w) ? [w, `last ${w}`, `next ${w}`] : [w],
 );
 
-PHRASES.push("next month", "last month", "next year", "last year");
 
 /**
  * Convert a natural-language phrase into a moment date instance.
@@ -95,10 +92,34 @@ function phraseToMoment(phrase: string): moment.Moment | null {
                 const n = parseInt(ago[1]);
                 if (!isNaN(n)) return now.clone().subtract(n * (ago[2].startsWith('week') ? 7 : 1), "day");
         }
-        if (lower === "next month") return now.clone().add(1, "month");
-        if (lower === "last month") return now.clone().subtract(1, "month");
-        if (lower === "next year") return now.clone().add(1, "year");
-        if (lower === "last year") return now.clone().subtract(1, "year");
+
+        const lastMd = lower.match(/^last\s+(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+(\d{1,2}\w*)$/i);
+        if (lastMd) {
+                let monthName = lastMd[1];
+                if (monthName.length <= 3) {
+                        const idx = ["jan","feb","mar","apr","may","jun","jul","aug","sep","oct","nov","dec"].indexOf(monthName.slice(0,3));
+                        monthName = ["january","february","march","april","may","june","july","august","september","october","november","december"][idx];
+                }
+                const dayNum = parseInt(lastMd[2]);
+                if (!isNaN(dayNum)) {
+                        const target = now.clone().month(monthName).date(dayNum);
+                        if (!target.isValid()) return null;
+                        if (!target.isBefore(now, "day")) target.subtract(1, "year");
+                        return target;
+                }
+        }
+
+        const justDay = lower.match(/^(?:the\s+)?(\d{1,2})(?:st|nd|rd|th)?$/);
+        if (justDay) {
+                const dayNum = parseInt(justDay[1]);
+                if (!isNaN(dayNum)) {
+                        const target = now.clone();
+                        if (dayNum <= target.date()) target.add(1, "month");
+                        target.date(dayNum);
+                        if (!target.isValid() || target.date() !== dayNum) return null;
+                        return target;
+                }
+        }
 
         const weekdays = WEEKDAYS;
 
@@ -306,7 +327,13 @@ class DDSuggest extends EditorSuggest<string> {
                                 ) {
                                         await this.app.vault.createFolder(folder);
                                 }
-                                await this.app.vault.create(target, settings.template || "");
+                                let tpl = "";
+                                const daily = (this.app as any).internalPlugins?.plugins?.["daily-notes"]?.instance?.options;
+                                if (daily?.template) {
+                                        const f = this.app.vault.getAbstractFileByPath(daily.template);
+                                        if (f) tpl = await this.app.vault.read(f as TFile);
+                                }
+                                await this.app.vault.create(target, tpl);
                                 if (settings.openOnCreate && this.app.workspace?.openLinkText) {
                                         this.app.workspace.openLinkText(target, "", false);
                                 }
@@ -470,16 +497,5 @@ class DDSettingTab extends PluginSettingTab {
                                         }),
                         );
 
-                new Setting(containerEl)
-                        .setName("Template for new notes")
-                        .addText((t) =>
-                                t
-                                        .setPlaceholder("")
-                                        .setValue(this.plugin.settings.template)
-                                        .onChange(async (v: string) => {
-                                                this.plugin.settings.template = v;
-                                                await this.plugin.saveSettings();
-                                        }),
-                        );
         }
 }

--- a/src/obsidian.d.ts
+++ b/src/obsidian.d.ts
@@ -6,6 +6,7 @@ declare module "obsidian" {
         getAbstractFileByPath(path: string): any;
         createFolder(path: string): Promise<void>;
         create(path: string, data: string): Promise<void>;
+        read(file: any): Promise<string>;
     }
 
     export class Workspace {


### PR DESCRIPTION
## Summary
- remove template setting and use daily note template
- support `last <month> <day>` and phrases like `the 24th`
- drop generic month/year phrases
- update tests for new behaviour

## Testing
- `npm test`