### PR TITLE
Fix accept key handling

### DIFF
--- a/main.js
+++ b/main.js
@@ -241,7 +241,12 @@ class DDSuggest extends obsidian_1.EditorSuggest {
      * Replace the typed phrase with the selected wikilink and optionally
      * create the daily note on disk.
      */
-    selectSuggestion(value, ev) {
+    /**
+     * Handle a suggestion being chosen.  Obsidian renamed this hook from
+     * `selectSuggestion` to `onChooseSuggestion` in newer releases.  We
+     * implement both signatures for compatibility across versions.
+     */
+    onChooseSuggestion(value, ev) {
         const { editor, start, end, query } = this.context;
         const { settings } = this.plugin;
         /* ----------------------------------------------------------------
@@ -311,6 +316,11 @@ class DDSuggest extends obsidian_1.EditorSuggest {
             })();
         }
         this.close();
+    }
+    // Older versions of Obsidian call this method instead.  Keep it as a
+    // thin wrapper for backwards compatibility.
+    selectSuggestion(value, ev) {
+        this.onChooseSuggestion(value, ev);
     }
 }
 /* ------------------------------------------------------------------ */

--- a/src/main.ts
+++ b/src/main.ts
@@ -289,7 +289,12 @@ class DDSuggest extends EditorSuggest<string> {
          * Replace the typed phrase with the selected wikilink and optionally
          * create the daily note on disk.
          */
-        selectSuggestion(value: string, ev: KeyboardEvent | MouseEvent) {
+        /**
+         * Handle a suggestion being chosen.  Obsidian renamed this hook from
+         * `selectSuggestion` to `onChooseSuggestion` in newer releases.  We
+         * implement both signatures for compatibility across versions.
+         */
+        onChooseSuggestion(value: string, ev: KeyboardEvent | MouseEvent) {
                 const { editor, start, end, query } = this.context!;
                 const { settings } = this.plugin;
 	
@@ -373,8 +378,14 @@ class DDSuggest extends EditorSuggest<string> {
                         })();
                 }
 	
-		this.close();
-	}
+                this.close();
+        }
+
+        // Older versions of Obsidian call this method instead.  Keep it as a
+        // thin wrapper for backwards compatibility.
+        selectSuggestion(value: string, ev: KeyboardEvent | MouseEvent) {
+                this.onChooseSuggestion(value, ev);
+        }
 	
 	
 }


### PR DESCRIPTION
## Summary
- ensure compatibility with new Obsidian API by renaming `selectSuggestion` to `onChooseSuggestion`
- keep `selectSuggestion` as wrapper for backwards compatibility
- rebuild main.js

## Testing
- `npm test`