### PR TITLE
Add dropdown settings options

### DIFF
--- a/main.js
+++ b/main.js
@@ -402,13 +402,25 @@ class DDSettingTab extends obsidian_1.PluginSettingTab {
         containerEl.empty();
         new obsidian_1.Setting(containerEl)
             .setName("Date format")
-            .addText((t) => t
-            .setPlaceholder("YYYY-MM-DD")
-            .setValue(this.plugin.settings.dateFormat)
-            .onChange(async (v) => {
-            this.plugin.settings.dateFormat = v.trim() || "YYYY-MM-DD";
-            await this.plugin.saveSettings();
-        }));
+            .addDropdown((d) => {
+            const formats = {
+                "YYYY-MM-DD": (0, obsidian_1.moment)().format("YYYY-MM-DD"),
+                "DD-MM-YYYY": (0, obsidian_1.moment)().format("DD-MM-YYYY"),
+                "MM-DD-YYYY": (0, obsidian_1.moment)().format("MM-DD-YYYY"),
+                "YYYYMMDD": (0, obsidian_1.moment)().format("YYYYMMDD"),
+            };
+            for (const fmt in formats) {
+                d.addOption(fmt, `${fmt} — ${formats[fmt]}`);
+            }
+            if (!(this.plugin.settings.dateFormat in formats)) {
+                d.addOption(this.plugin.settings.dateFormat, this.plugin.settings.dateFormat);
+            }
+            d.setValue(this.plugin.settings.dateFormat)
+                .onChange(async (v) => {
+                this.plugin.settings.dateFormat = v;
+                await this.plugin.saveSettings();
+            });
+        });
         new obsidian_1.Setting(containerEl)
             .setName("Daily-note folder")
             .addText((t) => t
@@ -436,14 +448,16 @@ class DDSettingTab extends obsidian_1.PluginSettingTab {
         }));
         new obsidian_1.Setting(containerEl)
             .setName("Accept key")
-            .addText((t) => t
-            .setPlaceholder("Tab")
-            .setValue(this.plugin.settings.acceptKey)
-            .onChange(async (v) => {
-            const val = v.trim() === "Enter" ? "Enter" : "Tab";
-            this.plugin.settings.acceptKey = val;
-            await this.plugin.saveSettings();
-        }));
+            .addDropdown((d) => {
+            d.addOption("Tab", "Tab");
+            d.addOption("Enter", "Enter");
+            d.setValue(this.plugin.settings.acceptKey)
+                .onChange(async (v) => {
+                const val = v === "Enter" ? "Enter" : "Tab";
+                this.plugin.settings.acceptKey = val;
+                await this.plugin.saveSettings();
+            });
+        });
         new obsidian_1.Setting(containerEl)
             .setName("Shift+<key> inserts plain link")
             .addToggle((t) => t
@@ -454,13 +468,20 @@ class DDSettingTab extends obsidian_1.PluginSettingTab {
         }));
         new obsidian_1.Setting(containerEl)
             .setName("Alias style")
-            .addText((t) => t
-            .setPlaceholder("capitalize")
-            .setValue(this.plugin.settings.aliasFormat)
-            .onChange(async (v) => {
-            this.plugin.settings.aliasFormat = v.trim() || "capitalize";
-            await this.plugin.saveSettings();
-        }));
+            .addDropdown((d) => {
+            d.addOption("capitalize", "Capitalize");
+            d.addOption("keep", "Keep typed");
+            d.addOption("date", "Formatted date");
+            if (!["capitalize", "keep", "date"].includes(this.plugin.settings.aliasFormat)) {
+                d.addOption(this.plugin.settings.aliasFormat, this.plugin.settings.aliasFormat);
+            }
+            d.setValue(this.plugin.settings.aliasFormat)
+                .onChange(async (v) => {
+                const val = v || "capitalize";
+                this.plugin.settings.aliasFormat = val;
+                await this.plugin.saveSettings();
+            });
+        });
         new obsidian_1.Setting(containerEl)
             .setName("Custom dates (JSON)")
             .addText((t) => t

--- a/src/main.ts
+++ b/src/main.ts
@@ -468,17 +468,27 @@ class DDSettingTab extends PluginSettingTab {
 		const { containerEl } = this;
 		containerEl.empty();
 
-		new Setting(containerEl)
-			.setName("Date format")
-			.addText((t) =>
-				t
-					.setPlaceholder("YYYY-MM-DD")
-					.setValue(this.plugin.settings.dateFormat)
+                new Setting(containerEl)
+                        .setName("Date format")
+                        .addDropdown((d: any) => {
+                                const formats: Record<string, string> = {
+                                        "YYYY-MM-DD": moment().format("YYYY-MM-DD"),
+                                        "DD-MM-YYYY": moment().format("DD-MM-YYYY"),
+                                        "MM-DD-YYYY": moment().format("MM-DD-YYYY"),
+                                        "YYYYMMDD": moment().format("YYYYMMDD"),
+                                };
+                                for (const fmt in formats) {
+                                        d.addOption(fmt, `${fmt} — ${formats[fmt]}`);
+                                }
+                                if (!(this.plugin.settings.dateFormat in formats)) {
+                                        d.addOption(this.plugin.settings.dateFormat, this.plugin.settings.dateFormat);
+                                }
+                                d.setValue(this.plugin.settings.dateFormat)
                                         .onChange(async (v: string) => {
-                                                this.plugin.settings.dateFormat = v.trim() || "YYYY-MM-DD";
+                                                this.plugin.settings.dateFormat = v;
                                                 await this.plugin.saveSettings();
-                                        }),
-			);
+                                        });
+                        });
 
 		new Setting(containerEl)
 			.setName("Daily-note folder")
@@ -517,16 +527,16 @@ class DDSettingTab extends PluginSettingTab {
 
                 new Setting(containerEl)
                         .setName("Accept key")
-                        .addText((t) =>
-                                t
-                                        .setPlaceholder("Tab")
-                                        .setValue(this.plugin.settings.acceptKey)
+                        .addDropdown((d: any) => {
+                                d.addOption("Tab", "Tab");
+                                d.addOption("Enter", "Enter");
+                                d.setValue(this.plugin.settings.acceptKey)
                                         .onChange(async (v: string) => {
-                                                const val = v.trim() === "Enter" ? "Enter" : "Tab";
+                                                const val = v === "Enter" ? "Enter" : "Tab";
                                                 this.plugin.settings.acceptKey = val as any;
                                                 await this.plugin.saveSettings();
-                                        }),
-                        );
+                                        });
+                        });
 
                 new Setting(containerEl)
                         .setName("Shift+<key> inserts plain link")
@@ -541,15 +551,20 @@ class DDSettingTab extends PluginSettingTab {
 
                 new Setting(containerEl)
                         .setName("Alias style")
-                        .addText((t) =>
-                                t
-                                        .setPlaceholder("capitalize")
-                                        .setValue(this.plugin.settings.aliasFormat)
+                        .addDropdown((d: any) => {
+                                d.addOption("capitalize", "Capitalize");
+                                d.addOption("keep", "Keep typed");
+                                d.addOption("date", "Formatted date");
+                                if (!["capitalize", "keep", "date"].includes(this.plugin.settings.aliasFormat)) {
+                                        d.addOption(this.plugin.settings.aliasFormat, this.plugin.settings.aliasFormat);
+                                }
+                                d.setValue(this.plugin.settings.aliasFormat)
                                         .onChange(async (v: string) => {
-                                                this.plugin.settings.aliasFormat = (v.trim() as any) || "capitalize";
+                                                const val = (v as any) || "capitalize";
+                                                this.plugin.settings.aliasFormat = val;
                                                 await this.plugin.saveSettings();
-                                        }),
-                        );
+                                        });
+                        });
 
                 new Setting(containerEl)
                         .setName("Custom dates (JSON)")

--- a/src/obsidian.d.ts
+++ b/src/obsidian.d.ts
@@ -53,6 +53,7 @@ declare module "obsidian" {
         setName(name: string): this;
         addText(cb: (t: any) => any): this;
         addToggle(cb: (t: any) => any): this;
+        addDropdown(cb: (d: any) => any): this;
     }
 
     export interface TFile {}

--- a/test/test.js
+++ b/test/test.js
@@ -66,7 +66,7 @@
   class KeyboardEvent { constructor(init) { Object.assign(this, init); } }
   class Plugin { constructor() { this.app = { vault:{}, workspace:{} }; } }
   class PluginSettingTab {}
-  class Setting { setName(){return this;} addText(){return this;} addToggle(){return this;} }
+  class Setting { setName(){return this;} addText(){return this;} addToggle(){return this;} addDropdown(){return this;} }
 
   const WEEKDAYS = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];
   const BASE_WORDS = ['today','yesterday','tomorrow', ...WEEKDAYS];


### PR DESCRIPTION
## Summary
- add `addDropdown` to testing stubs
- provide dropdowns for date format, accept key, and alias style
- update compiled main.js

## Testing
- `npm run test`