### PR TITLE
Improve settings UI with dropdowns

### DIFF
--- a/main.js
+++ b/main.js
@@ -402,11 +402,17 @@ class DDSettingTab extends obsidian_1.PluginSettingTab {
         containerEl.empty();
         new obsidian_1.Setting(containerEl)
             .setName("Date format")
-            .addText((t) => t
-            .setPlaceholder("YYYY-MM-DD")
+            .setDesc("Format used when inserting dates")
+            .addDropdown((d) => d
+            .addOptions({
+            "YYYY-MM-DD": "YYYY-MM-DD",
+            "DD-MM-YYYY": "DD-MM-YYYY",
+            "MM-DD-YYYY": "MM-DD-YYYY",
+            "YYYY/MM/DD": "YYYY/MM/DD",
+        })
             .setValue(this.plugin.settings.dateFormat)
             .onChange(async (v) => {
-            this.plugin.settings.dateFormat = v.trim() || "YYYY-MM-DD";
+            this.plugin.settings.dateFormat = v;
             await this.plugin.saveSettings();
         }));
         new obsidian_1.Setting(containerEl)
@@ -436,12 +442,12 @@ class DDSettingTab extends obsidian_1.PluginSettingTab {
         }));
         new obsidian_1.Setting(containerEl)
             .setName("Accept key")
-            .addText((t) => t
-            .setPlaceholder("Tab")
+            .setDesc("Key used to accept a suggestion")
+            .addDropdown((d) => d
+            .addOptions({ Tab: "Tab", Enter: "Enter" })
             .setValue(this.plugin.settings.acceptKey)
             .onChange(async (v) => {
-            const val = v.trim() === "Enter" ? "Enter" : "Tab";
-            this.plugin.settings.acceptKey = val;
+            this.plugin.settings.acceptKey = v;
             await this.plugin.saveSettings();
         }));
         new obsidian_1.Setting(containerEl)
@@ -454,11 +460,16 @@ class DDSettingTab extends obsidian_1.PluginSettingTab {
         }));
         new obsidian_1.Setting(containerEl)
             .setName("Alias style")
-            .addText((t) => t
-            .setPlaceholder("capitalize")
+            .setDesc("How the alias part of links is formatted")
+            .addDropdown((d) => d
+            .addOptions({
+            capitalize: "Capitalize phrase",
+            keep: "Keep typed text",
+            date: "Format as date",
+        })
             .setValue(this.plugin.settings.aliasFormat)
             .onChange(async (v) => {
-            this.plugin.settings.aliasFormat = v.trim() || "capitalize";
+            this.plugin.settings.aliasFormat = v;
             await this.plugin.saveSettings();
         }));
         new obsidian_1.Setting(containerEl)

--- a/src/main.ts
+++ b/src/main.ts
@@ -468,17 +468,23 @@ class DDSettingTab extends PluginSettingTab {
 		const { containerEl } = this;
 		containerEl.empty();
 
-		new Setting(containerEl)
-			.setName("Date format")
-			.addText((t) =>
-				t
-					.setPlaceholder("YYYY-MM-DD")
-					.setValue(this.plugin.settings.dateFormat)
+                new Setting(containerEl)
+                        .setName("Date format")
+                        .setDesc("Format used when inserting dates")
+                        .addDropdown((d) =>
+                                d
+                                        .addOptions({
+                                                "YYYY-MM-DD": "YYYY-MM-DD",
+                                                "DD-MM-YYYY": "DD-MM-YYYY",
+                                                "MM-DD-YYYY": "MM-DD-YYYY",
+                                                "YYYY/MM/DD": "YYYY/MM/DD",
+                                        })
+                                        .setValue(this.plugin.settings.dateFormat)
                                         .onChange(async (v: string) => {
-                                                this.plugin.settings.dateFormat = v.trim() || "YYYY-MM-DD";
+                                                this.plugin.settings.dateFormat = v;
                                                 await this.plugin.saveSettings();
                                         }),
-			);
+                        );
 
 		new Setting(containerEl)
 			.setName("Daily-note folder")
@@ -517,13 +523,13 @@ class DDSettingTab extends PluginSettingTab {
 
                 new Setting(containerEl)
                         .setName("Accept key")
-                        .addText((t) =>
-                                t
-                                        .setPlaceholder("Tab")
+                        .setDesc("Key used to accept a suggestion")
+                        .addDropdown((d) =>
+                                d
+                                        .addOptions({ Tab: "Tab", Enter: "Enter" })
                                         .setValue(this.plugin.settings.acceptKey)
                                         .onChange(async (v: string) => {
-                                                const val = v.trim() === "Enter" ? "Enter" : "Tab";
-                                                this.plugin.settings.acceptKey = val as any;
+                                                this.plugin.settings.acceptKey = v as any;
                                                 await this.plugin.saveSettings();
                                         }),
                         );
@@ -541,12 +547,17 @@ class DDSettingTab extends PluginSettingTab {
 
                 new Setting(containerEl)
                         .setName("Alias style")
-                        .addText((t) =>
-                                t
-                                        .setPlaceholder("capitalize")
+                        .setDesc("How the alias part of links is formatted")
+                        .addDropdown((d) =>
+                                d
+                                        .addOptions({
+                                                capitalize: "Capitalize phrase",
+                                                keep: "Keep typed text",
+                                                date: "Format as date",
+                                        })
                                         .setValue(this.plugin.settings.aliasFormat)
                                         .onChange(async (v: string) => {
-                                                this.plugin.settings.aliasFormat = (v.trim() as any) || "capitalize";
+                                                this.plugin.settings.aliasFormat = v as any;
                                                 await this.plugin.saveSettings();
                                         }),
                         );

--- a/src/obsidian.d.ts
+++ b/src/obsidian.d.ts
@@ -51,8 +51,10 @@ declare module "obsidian" {
     export class Setting {
         constructor(el: HTMLElement);
         setName(name: string): this;
+        setDesc(desc: string): this;
         addText(cb: (t: any) => any): this;
         addToggle(cb: (t: any) => any): this;
+        addDropdown(cb: (d: any) => any): this;
     }
 
     export interface TFile {}

--- a/test/test.js
+++ b/test/test.js
@@ -66,7 +66,13 @@
   class KeyboardEvent { constructor(init) { Object.assign(this, init); } }
   class Plugin { constructor() { this.app = { vault:{}, workspace:{} }; } }
   class PluginSettingTab {}
-  class Setting { setName(){return this;} addText(){return this;} addToggle(){return this;} }
+  class Setting {
+    setName(){ return this; }
+    setDesc(){ return this; }
+    addText(){ return this; }
+    addToggle(){ return this; }
+    addDropdown(){ return this; }
+  }
 
   const WEEKDAYS = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];
   const BASE_WORDS = ['today','yesterday','tomorrow', ...WEEKDAYS];


### PR DESCRIPTION
## Summary
- add dropdown options to `Date format`, `Accept key`, and `Alias style`
- extend Obsidian stubs for dropdown support
- adjust tests for new Setting API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6839fb8b4f508326b835e300d6c298b5