### PR TITLE
Fix Shift accept key functionality

### DIFF
--- a/main.js
+++ b/main.js
@@ -276,7 +276,7 @@ class DDSuggest extends obsidian_1.EditorSuggest {
            3. Insert, respecting the Shift-modifier behaviour
         ----------------------------------------------------------------- */
         let final = link;
-        if (ev instanceof KeyboardEvent) {
+        if (ev && ev.key != null) {
             const key = ev.key === "Enter" ? "Enter" : ev.key === "Tab" ? "Tab" : "";
             if (key && key !== settings.acceptKey)
                 return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -328,10 +328,10 @@ class DDSuggest extends EditorSuggest<string> {
 		   3. Insert, respecting the Shift-modifier behaviour
 		----------------------------------------------------------------- */
                 let final = link;
-                if (ev instanceof KeyboardEvent) {
-                        const key = ev.key === "Enter" ? "Enter" : ev.key === "Tab" ? "Tab" : "";
+                if (ev && (ev as any).key != null) {
+                        const key = (ev as any).key === "Enter" ? "Enter" : (ev as any).key === "Tab" ? "Tab" : "";
                         if (key && key !== settings.acceptKey) return;
-                        if (ev.shiftKey && settings.noAliasWithShift) {
+                        if ((ev as any).shiftKey && settings.noAliasWithShift) {
                                 final = `[[${linkPath}]]`;
                         }
                 }


### PR DESCRIPTION
## Summary
- handle cross-realm KeyboardEvent when using Shift + accept key
- rebuild `main.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683a01ced85483269236e3b7760b3751