### PR TITLE
Improve Shift+accept key behavior

### DIFF
--- a/main.js
+++ b/main.js
@@ -283,6 +283,9 @@ class DDSuggest extends obsidian_1.EditorSuggest {
             if (ev.shiftKey && settings.noAliasWithShift) {
                 final = `[[${linkPath}]]`;
             }
+            if (typeof ev.preventDefault === "function") {
+                ev.preventDefault();
+            }
         }
         editor.replaceRange(final, start, end);
         /* ----------------------------------------------------------------

--- a/src/main.ts
+++ b/src/main.ts
@@ -334,6 +334,9 @@ class DDSuggest extends EditorSuggest<string> {
                         if ((ev as any).shiftKey && settings.noAliasWithShift) {
                                 final = `[[${linkPath}]]`;
                         }
+                        if (typeof (ev as any).preventDefault === "function") {
+                                (ev as any).preventDefault();
+                        }
                 }
 
                 editor.replaceRange(

--- a/test/test.js
+++ b/test/test.js
@@ -235,8 +235,20 @@
   tSugg.context = { editor: { replaceRange:(t)=>inserted2.push(t), getLine:()=>'' }, start:{line:0,ch:0}, end:{line:0,ch:3}, query:'tom' };
   tSugg.selectSuggestion('2024-05-09', new KeyboardEvent({ key:'Tab', shiftKey:false }));
   assert.strictEqual(inserted2.length, 0);
-  tSugg.selectSuggestion('2024-05-09', new KeyboardEvent({ key:'Enter', shiftKey:false }));
+  const ev1 = new KeyboardEvent({ key:'Enter', shiftKey:false });
+  let called1 = false;
+  ev1.preventDefault = () => { called1 = true; };
+  tSugg.selectSuggestion('2024-05-09', ev1);
+  assert.ok(called1);
   assert.strictEqual(inserted2.pop(), '[[Daily/2024-05-09|Tomorrow]]');
+
+  const ev2 = new KeyboardEvent({ key:'Enter', shiftKey:true });
+  let called2 = false;
+  ev2.preventDefault = () => { called2 = true; };
+  tSugg.context = { editor: { replaceRange:(t)=>inserted2.push(t), getLine:()=>'' }, start:{line:0,ch:0}, end:{line:0,ch:3}, query:'tom' };
+  tSugg.selectSuggestion('2024-05-09', ev2);
+  assert.ok(called2);
+  assert.strictEqual(inserted2.pop(), '[[Daily/2024-05-09]]');
 
   /* ------------------------------------------------------------------ */
   /* custom dates feature                                               */


### PR DESCRIPTION
## Summary
- prevent newline when using Shift with the accept key
- add tests to ensure `preventDefault` is triggered on Enter

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683a039af70c8326821e1998d183baa3