### PR TITLE
Add custom date mapping UI

### DIFF
--- a/main.js
+++ b/main.js
@@ -493,6 +493,40 @@ class DDSettingTab extends obsidian_1.PluginSettingTab {
             this.plugin.settings.aliasFormat = v;
             await this.plugin.saveSettings();
         }));
+        containerEl.createDiv({ text: "Custom date mappings" });
+        Object.entries(this.plugin.settings.customDates).forEach(([p, d]) => {
+            let phrase = p;
+            let date = d;
+            new obsidian_1.Setting(containerEl)
+                .addText(t => t.setPlaceholder("Phrase")
+                .setValue(phrase)
+                .onChange(async (v) => {
+                const map = { ...this.plugin.settings.customDates };
+                delete map[phrase];
+                phrase = v;
+                map[phrase] = date;
+                this.plugin.settings.customDates = map;
+                await this.plugin.saveSettings();
+            }))
+                .addText(t => t.setPlaceholder("MM-DD")
+                .setValue(date)
+                .onChange(async (v) => {
+                date = v;
+                this.plugin.settings.customDates[phrase] = v;
+                await this.plugin.saveSettings();
+            }))
+                .addExtraButton(b => b.onClick(async () => {
+                delete this.plugin.settings.customDates[phrase];
+                await this.plugin.saveSettings();
+                this.display();
+            }));
+        });
+        new obsidian_1.Setting(containerEl)
+            .addButton(b => b.setButtonText("Add")
+            .onClick(() => {
+            this.plugin.settings.customDates["New phrase"] = "01-01";
+            this.display();
+        }));
         new obsidian_1.Setting(containerEl)
             .setName("Custom dates (JSON)")
             .addText((t) => t

--- a/src/main.ts
+++ b/src/main.ts
@@ -585,6 +585,45 @@ class DDSettingTab extends PluginSettingTab {
                                         }),
                         );
 
+                containerEl.createDiv({ text: "Custom date mappings" });
+                Object.entries(this.plugin.settings.customDates).forEach(([p, d]) => {
+                        let phrase = p;
+                        let date = d;
+                        new Setting(containerEl)
+                                .addText(t =>
+                                        t.setPlaceholder("Phrase")
+                                         .setValue(phrase)
+                                         .onChange(async (v: string) => {
+                                                 const map = { ...this.plugin.settings.customDates };
+                                                 delete map[phrase];
+                                                 phrase = v;
+                                                 map[phrase] = date;
+                                                 this.plugin.settings.customDates = map;
+                                                 await this.plugin.saveSettings();
+                                         }))
+                                .addText(t =>
+                                        t.setPlaceholder("MM-DD")
+                                         .setValue(date)
+                                         .onChange(async (v: string) => {
+                                                 date = v;
+                                                 this.plugin.settings.customDates[phrase] = v;
+                                                 await this.plugin.saveSettings();
+                                         }))
+                                .addExtraButton(b =>
+                                        b.onClick(async () => {
+                                                delete this.plugin.settings.customDates[phrase];
+                                                await this.plugin.saveSettings();
+                                                this.display();
+                                        }));
+                });
+                new Setting(containerEl)
+                        .addButton(b =>
+                                b.setButtonText("Add")
+                                 .onClick(() => {
+                                         this.plugin.settings.customDates["New phrase"] = "01-01";
+                                         this.display();
+                                 }));
+
                 new Setting(containerEl)
                         .setName("Custom dates (JSON)")
                         .addText((t) =>

--- a/src/obsidian.d.ts
+++ b/src/obsidian.d.ts
@@ -55,6 +55,15 @@ declare module "obsidian" {
         addText(cb: (t: any) => any): this;
         addToggle(cb: (t: any) => any): this;
         addDropdown(cb: (d: any) => any): this;
+        addButton(cb: (b: any) => any): this;
+        addExtraButton(cb: (b: any) => any): this;
+    }
+
+    export class ButtonComponent {
+        setButtonText(text: string): this;
+        setTooltip(text: string): this;
+        setIcon(icon: string): this;
+        onClick(callback: (evt?: any) => any): this;
     }
 
     export interface TFile {}

--- a/test/test.js
+++ b/test/test.js
@@ -72,6 +72,8 @@
     addText(){ return this; }
     addToggle(){ return this; }
     addDropdown(){ return this; }
+    addButton(){ return this; }
+    addExtraButton(){ return this; }
   }
 
   const WEEKDAYS = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];


### PR DESCRIPTION
## Summary
- extend Obsidian stubs with Button methods
- expose dummy methods in test runtime
- add UI for managing custom date mappings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683a141e53e483269de0fee7a1a46430