### PR TITLE
Add multi-word custom phrase detection

### DIFF
--- a/main.js
+++ b/main.js
@@ -162,46 +162,38 @@ class DDSuggest extends obsidian_1.EditorSuggest {
      */
     onTrigger(cursor, editor, _file) {
         const lineBefore = editor.getLine(cursor.line).slice(0, cursor.ch);
-        // Split the text before the cursor and inspect the last two
-        // tokens so that phrases like "next friday" are handled.
-        const tokens = lineBefore.split(/\s+/).filter((t) => t.length);
-        if (tokens.length === 0)
+        // Track word positions so we can look back multiple words
+        const words = [];
+        lineBefore.replace(/\S+/g, (w, off) => {
+            words.push({ word: w, offset: off });
+            return "";
+        });
+        if (words.length === 0)
             return null;
-        let prefix = tokens[tokens.length - 1]; // current fragment
-        let startCh = cursor.ch - prefix.length;
-        const maybePrev = tokens[tokens.length - 2];
-        let hasQualifier = false;
-        if (maybePrev) {
-            const combined = `${maybePrev} ${prefix}`;
-            if (phraseToMoment(combined)) {
-                prefix = combined;
-                startCh -= maybePrev.length + 1;
-            }
-            else if (["last", "next"].includes(maybePrev.toLowerCase())) {
-                prefix = combined;
-                startCh -= maybePrev.length + 1;
-                hasQualifier = true;
-            }
-        }
-        const query = prefix.toLowerCase().trim();
-        /* -----------------------------------------------------------
-           Guard-rails
-           ----------------------------------------------------------- */
-        // never pop on bare/partial "last" / "next"
-        if (["l", "la", "las", "last", "n", "ne", "nex", "next"].includes(query))
-            return null;
-        // for stand-alone phrases (no qualifier) require ≥3 chars
-        if (!hasQualifier && query.length < 3)
-            return null;
-        // must map to a known phrase or a recognised month/day
         const all = this.plugin.allPhrases();
-        if (!all.some((p) => p.startsWith(query)) && !phraseToMoment(query))
-            return null;
-        return {
-            start: { line: cursor.line, ch: startCh },
-            end: { line: cursor.line, ch: cursor.ch },
-            query,
-        };
+        const MAX = 6;
+        for (let k = Math.min(words.length, MAX); k >= 1; k--) {
+            const slice = words.slice(words.length - k);
+            const startCh = slice[0].offset;
+            const prefix = lineBefore.slice(startCh);
+            const query = prefix.toLowerCase().trim();
+            const hasQualifier = query.startsWith("last ") || query.startsWith("next ");
+            // never pop on bare/partial "last" / "next"
+            if (["l", "la", "las", "last", "n", "ne", "nex", "next"].includes(query))
+                continue;
+            // for stand-alone phrases (no qualifier) require ≥3 chars
+            if (!hasQualifier && query.length < 3)
+                continue;
+            // must map to a known phrase or a recognised month/day
+            if (!all.some((p) => p.startsWith(query)) && !phraseToMoment(query))
+                continue;
+            return {
+                start: { line: cursor.line, ch: startCh },
+                end: { line: cursor.line, ch: cursor.ch },
+                query,
+            };
+        }
+        return null;
     }
     /**
      * Build the list of suggestion strings that should be shown for the
@@ -492,6 +484,40 @@ class DDSettingTab extends obsidian_1.PluginSettingTab {
             .onChange(async (v) => {
             this.plugin.settings.aliasFormat = v;
             await this.plugin.saveSettings();
+        }));
+        containerEl.createDiv({ text: "Custom date mappings" });
+        Object.entries(this.plugin.settings.customDates).forEach(([p, d]) => {
+            let phrase = p;
+            let date = d;
+            new obsidian_1.Setting(containerEl)
+                .addText(t => t.setPlaceholder("Phrase")
+                .setValue(phrase)
+                .onChange(async (v) => {
+                const map = { ...this.plugin.settings.customDates };
+                delete map[phrase];
+                phrase = v;
+                map[phrase] = date;
+                this.plugin.settings.customDates = map;
+                await this.plugin.saveSettings();
+            }))
+                .addText(t => t.setPlaceholder("MM-DD")
+                .setValue(date)
+                .onChange(async (v) => {
+                date = v;
+                this.plugin.settings.customDates[phrase] = v;
+                await this.plugin.saveSettings();
+            }))
+                .addExtraButton(b => b.onClick(async () => {
+                delete this.plugin.settings.customDates[phrase];
+                await this.plugin.saveSettings();
+                this.display();
+            }));
+        });
+        new obsidian_1.Setting(containerEl)
+            .addButton(b => b.setButtonText("Add")
+            .onClick(() => {
+            this.plugin.settings.customDates["New phrase"] = "01-01";
+            this.display();
         }));
         new obsidian_1.Setting(containerEl)
             .setName("Custom dates (JSON)")

--- a/src/obsidian.d.ts
+++ b/src/obsidian.d.ts
@@ -55,6 +55,15 @@ declare module "obsidian" {
         addText(cb: (t: any) => any): this;
         addToggle(cb: (t: any) => any): this;
         addDropdown(cb: (d: any) => any): this;
+        addButton(cb: (b: any) => any): this;
+        addExtraButton(cb: (b: any) => any): this;
+    }
+
+    export class ButtonComponent {
+        setButtonText(text: string): this;
+        setTooltip(text: string): this;
+        setIcon(icon: string): this;
+        onClick(callback: (evt?: any) => any): this;
     }
 
     export interface TFile {}

--- a/test/test.js
+++ b/test/test.js
@@ -72,6 +72,8 @@
     addText(){ return this; }
     addToggle(){ return this; }
     addDropdown(){ return this; }
+    addButton(){ return this; }
+    addExtraButton(){ return this; }
   }
 
   const WEEKDAYS = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];
@@ -277,6 +279,20 @@
   assert.ok(list.includes('2024-08-22'));
   const converted2 = cPlugin.convertText('see you fall start');
   assert.strictEqual(converted2, 'see you [[2024-08-22|Fall Start]]');
+
+  // multi-word custom phrase detection via onTrigger
+  phraseToMoment.customDates = { 'start of the new semester': '08-22' };
+  const p2 = new DynamicDates();
+  p2.settings = Object.assign({}, plugin.settings, {
+    customDates: { 'start of the new semester': '08-22' }
+  });
+  const s2 = new DDSuggest({ vault:{}, workspace:{} }, p2);
+  const trig = s2.onTrigger(
+    { line:0, ch:25 },
+    { getLine:()=> 'start of the new semester' },
+    null
+  );
+  assert.ok(trig && trig.start.ch === 0);
 
   console.log('All tests passed');
 })();


### PR DESCRIPTION
## Summary
- detect phrases using up to six trailing words so long custom phrases trigger correctly
- test detection of a full custom phrase

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683a141e53e483269de0fee7a1a46430