### PR TITLE
Add custom casing for custom phrases

### DIFF
--- a/main.js
+++ b/main.js
@@ -251,8 +251,9 @@ class DDSuggest extends obsidian_1.EditorSuggest {
             phraseToMoment(p)?.format("YYYY-MM-DD") === targetDate);
         let phrase = query.toLowerCase();
         let alias;
+        const custom = this.plugin.customCanonical(phrase);
         if (settings.aliasFormat === "keep") {
-            alias = query;
+            alias = custom || query;
         }
         else if (settings.aliasFormat === "date") {
             alias = (0, obsidian_1.moment)(targetDate, "YYYY-MM-DD").format("MMMM Do");
@@ -260,20 +261,26 @@ class DDSuggest extends obsidian_1.EditorSuggest {
         else {
             if (candidates.length) {
                 phrase = candidates.sort((a, b) => a.length - b.length)[0];
-                const typedWords = query.split(/\s+/);
-                const phraseWords = phrase.split(/\s+/);
-                alias = phraseWords
-                    .map((w, i) => {
-                    const t = typedWords[i];
-                    if (t &&
-                        t.length === w.length &&
-                        t.toLowerCase() === w.toLowerCase() &&
-                        ["last", "next"].includes(w.toLowerCase())) {
-                        return t;
-                    }
-                    return w.replace(/\b\w/g, ch => ch.toUpperCase());
-                })
-                    .join(" ");
+                const canonical = this.plugin.customCanonical(phrase);
+                if (canonical) {
+                    alias = canonical;
+                }
+                else {
+                    const typedWords = query.split(/\s+/);
+                    const phraseWords = phrase.split(/\s+/);
+                    alias = phraseWords
+                        .map((w, i) => {
+                        const t = typedWords[i];
+                        if (t &&
+                            t.length === w.length &&
+                            t.toLowerCase() === w.toLowerCase() &&
+                            ["last", "next"].includes(w.toLowerCase())) {
+                            return t;
+                        }
+                        return w.replace(/\b\w/g, ch => ch.toUpperCase());
+                    })
+                        .join(" ");
+                }
             }
             else {
                 alias = (0, obsidian_1.moment)(targetDate, "YYYY-MM-DD").format("MMMM Do");
@@ -346,6 +353,15 @@ class DynamicDates extends obsidian_1.Plugin {
     allPhrases() {
         return [...PHRASES, ...Object.keys(this.settings.customDates || {}).map(p => p.toLowerCase())];
     }
+    /** Return the canonical form for a custom phrase, if any. */
+    customCanonical(lower) {
+        lower = lower.toLowerCase();
+        for (const p of Object.keys(this.settings.customDates || {})) {
+            if (p.toLowerCase() === lower)
+                return p;
+        }
+        return null;
+    }
     async onload() {
         await this.loadSettings();
         this.registerEditorSuggest(new DDSuggest(this.app, this));
@@ -382,8 +398,12 @@ class DynamicDates extends obsidian_1.Plugin {
             return null;
         const value = m.format(this.settings.dateFormat);
         const targetDate = m.format("YYYY-MM-DD");
+        const custom = this.customCanonical(phrase);
         let alias;
-        if (this.settings.aliasFormat === "keep") {
+        if (custom) {
+            alias = custom;
+        }
+        else if (this.settings.aliasFormat === "keep") {
             alias = phrase;
         }
         else if (this.settings.aliasFormat === "date") {
@@ -492,6 +512,40 @@ class DDSettingTab extends obsidian_1.PluginSettingTab {
             .onChange(async (v) => {
             this.plugin.settings.aliasFormat = v;
             await this.plugin.saveSettings();
+        }));
+        containerEl.createDiv({ text: "Custom date mappings" });
+        Object.entries(this.plugin.settings.customDates).forEach(([p, d]) => {
+            let phrase = p;
+            let date = d;
+            new obsidian_1.Setting(containerEl)
+                .addText(t => t.setPlaceholder("Phrase")
+                .setValue(phrase)
+                .onChange(async (v) => {
+                const map = { ...this.plugin.settings.customDates };
+                delete map[phrase];
+                phrase = v;
+                map[phrase] = date;
+                this.plugin.settings.customDates = map;
+                await this.plugin.saveSettings();
+            }))
+                .addText(t => t.setPlaceholder("MM-DD")
+                .setValue(date)
+                .onChange(async (v) => {
+                date = v;
+                this.plugin.settings.customDates[phrase] = v;
+                await this.plugin.saveSettings();
+            }))
+                .addExtraButton(b => b.onClick(async () => {
+                delete this.plugin.settings.customDates[phrase];
+                await this.plugin.saveSettings();
+                this.display();
+            }));
+        });
+        new obsidian_1.Setting(containerEl)
+            .addButton(b => b.setButtonText("Add")
+            .onClick(() => {
+            this.plugin.settings.customDates["New phrase"] = "01-01";
+            this.display();
         }));
         new obsidian_1.Setting(containerEl)
             .setName("Custom dates (JSON)")

--- a/src/obsidian.d.ts
+++ b/src/obsidian.d.ts
@@ -55,6 +55,15 @@ declare module "obsidian" {
         addText(cb: (t: any) => any): this;
         addToggle(cb: (t: any) => any): this;
         addDropdown(cb: (d: any) => any): this;
+        addButton(cb: (b: any) => any): this;
+        addExtraButton(cb: (b: any) => any): this;
+    }
+
+    export class ButtonComponent {
+        setButtonText(text: string): this;
+        setTooltip(text: string): this;
+        setIcon(icon: string): this;
+        onClick(callback: (evt?: any) => any): this;
     }
 
     export interface TFile {}

--- a/test/test.js
+++ b/test/test.js
@@ -72,6 +72,8 @@
     addText(){ return this; }
     addToggle(){ return this; }
     addDropdown(){ return this; }
+    addButton(){ return this; }
+    addExtraButton(){ return this; }
   }
 
   const WEEKDAYS = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];
@@ -115,7 +117,7 @@
   /* ------------------------------------------------------------------ */
   /* onTrigger guard rails                                             */
   /* ------------------------------------------------------------------ */
-  const plugin = { settings: { dateFormat: 'YYYY-MM-DD', autoCreate: false, acceptKey:'Tab', noAliasWithShift: true, aliasFormat:'capitalize', openOnCreate:false }, dailyFolder:'', allPhrases: () => PHRASES, getDailyFolder(){ return this.dailyFolder; } };
+  const plugin = { settings: { dateFormat: 'YYYY-MM-DD', autoCreate: false, acceptKey:'Tab', noAliasWithShift: true, aliasFormat:'capitalize', openOnCreate:false }, dailyFolder:'', allPhrases: () => PHRASES, getDailyFolder(){ return this.dailyFolder; }, customCanonical(){ return null; } };
   const app = { vault: {} };
   const sugg = new DDSuggest(app, plugin);
 
@@ -230,7 +232,7 @@
   /* ------------------------------------------------------------------ */
   /* onTrigger additional guard rails                                   */
   /* ------------------------------------------------------------------ */
-  const tPlugin = { settings: Object.assign({}, plugin.settings, { autoCreate: false }), dailyFolder:'Daily', allPhrases: () => PHRASES, getDailyFolder(){ return this.dailyFolder; } };
+  const tPlugin = { settings: Object.assign({}, plugin.settings, { autoCreate: false }), dailyFolder:'Daily', allPhrases: () => PHRASES, getDailyFolder(){ return this.dailyFolder; }, customCanonical(){ return null; } };
   const tApp = { vault:{}, workspace:{} };
   const tSugg = new DDSuggest(tApp, tPlugin);
   assert.strictEqual(tSugg.onTrigger({line:0,ch:4}, { getLine:()=> 'next' }, null), null);
@@ -276,7 +278,12 @@
   const list = cSugg.getSuggestions({ query:'fall st' });
   assert.ok(list.includes('2024-08-22'));
   const converted2 = cPlugin.convertText('see you fall start');
-  assert.strictEqual(converted2, 'see you [[2024-08-22|Fall Start]]');
+  assert.strictEqual(converted2, 'see you [[2024-08-22|fall start]]');
+
+  cPlugin.settings.customDates['Big Event'] = '02-03';
+  phraseToMoment.customDates = Object.fromEntries(Object.entries(cPlugin.settings.customDates).map(([k,v])=>[k.toLowerCase(),v]));
+  const converted3 = cPlugin.convertText('the Big Event is soon');
+  assert.strictEqual(converted3, 'the [[2025-02-03|Big Event]] is soon');
 
   console.log('All tests passed');
 })();


### PR DESCRIPTION
## Summary
- keep original casing from settings when inserting custom phrases
- provide helper for canonical phrase lookups
- add tests covering custom phrase casing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683a141e53e483269de0fee7a1a46430