### PR TITLE
Remove advanced custom dates text field

### DIFF
--- a/main.js
+++ b/main.js
@@ -526,17 +526,9 @@ class DDSettingTab extends obsidian_1.PluginSettingTab {
             this.plugin.settings.customDates["New phrase"] = "01-01";
             this.display();
         }));
-        new obsidian_1.Setting(containerEl)
-            .setName("Custom dates (JSON)")
-            .addText((t) => t
-            .setPlaceholder('{"phrase":"MM-DD"}')
-            .setValue(JSON.stringify(this.plugin.settings.customDates))
-            .onChange(async (v) => {
-            try {
-                this.plugin.settings.customDates = JSON.parse(v || '{}');
-            }
-            catch { }
-            await this.plugin.saveSettings();
-        }));
+        // A legacy JSON input for custom dates existed here in early
+        // versions of the plugin. It has been removed to simplify the
+        // settings UI while retaining support for custom phrases via
+        // the individual mapping fields above.
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -621,19 +621,10 @@ class DDSettingTab extends PluginSettingTab {
                                          this.display();
                                  }));
 
-                new Setting(containerEl)
-                        .setName("Custom dates (JSON)")
-                        .addText((t) =>
-                                t
-                                        .setPlaceholder('{"phrase":"MM-DD"}')
-                                        .setValue(JSON.stringify(this.plugin.settings.customDates))
-                                        .onChange(async (v: string) => {
-                                                try {
-                                                        this.plugin.settings.customDates = JSON.parse(v || '{}');
-                                                } catch {}
-                                                await this.plugin.saveSettings();
-                                        }),
-                        );
+                // A legacy JSON input for custom dates existed here in early
+                // versions of the plugin. It has been removed to simplify the
+                // settings UI while retaining support for custom phrases via
+                // the individual mapping fields above.
 
         }
 }


### PR DESCRIPTION
## Summary
- remove the obsolete "Custom dates (JSON)" setting
- update built JS

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_b_683d8f3424688326abd6ce2a3390a2d2