### PR TITLE
Handle template when creating daily notes

### DIFF
--- a/main.js
+++ b/main.js
@@ -318,6 +318,18 @@ class DDSuggest extends obsidian_1.EditorSuggest {
                     const f = this.app.vault.getAbstractFileByPath(daily.template);
                     if (f)
                         tpl = await this.app.vault.read(f);
+                    const templates = this.app.internalPlugins?.plugins?.["templates"]?.instance;
+                    if (templates) {
+                        try {
+                            if (typeof templates.parseTemplate === "function") {
+                                tpl = await templates.parseTemplate(tpl);
+                            }
+                            else if (typeof templates.replaceTemplates === "function") {
+                                tpl = await templates.replaceTemplates(tpl);
+                            }
+                        }
+                        catch { }
+                    }
                 }
                 await this.app.vault.create(target, tpl);
                 if (settings.openOnCreate && this.app.workspace?.openLinkText) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -381,6 +381,16 @@ class DDSuggest extends EditorSuggest<string> {
                                 if (daily?.template) {
                                         const f = this.app.vault.getAbstractFileByPath(daily.template);
                                         if (f) tpl = await this.app.vault.read(f as TFile);
+                                        const templates = (this.app as any).internalPlugins?.plugins?.["templates"]?.instance;
+                                        if (templates) {
+                                                try {
+                                                        if (typeof templates.parseTemplate === "function") {
+                                                                tpl = await templates.parseTemplate(tpl);
+                                                        } else if (typeof templates.replaceTemplates === "function") {
+                                                                tpl = await templates.replaceTemplates(tpl);
+                                                        }
+                                                } catch {}
+                                        }
                                 }
                                 await this.app.vault.create(target, tpl);
                                 if (settings.openOnCreate && this.app.workspace?.openLinkText) {

--- a/test/test.js
+++ b/test/test.js
@@ -176,7 +176,10 @@
     createFolder: (p) => { calls.push(['mkdir', p]); return { then: r => r() }; },
     create: (p, d) => { calls.push(['create', p, d]); return { then: r => r() }; },
   };
-  app.internalPlugins = { plugins: { 'daily-notes': { instance: { options: { template: 'tpl.md' } } } } };
+  app.internalPlugins = { plugins: { 
+    'daily-notes': { instance: { options: { template: 'tpl.md' } } },
+    'templates': { instance: { parseTemplate: (t) => { calls.push(['tpl', t]); return t.toUpperCase(); } } }
+  } };
   app.workspace = { openLinkText:(p)=>calls.push(['open', p]) };
   const ed2 = { getLine:()=>'', replaceRange:(t)=>calls.push(['insert', t]) };
   sugg.app = app;
@@ -191,7 +194,8 @@
     ['mkdir', 'Daily'],
     ['check', 'tpl.md'],
     ['read', 'tpl.md'],
-    ['create', 'Daily/2024-05-09.md', '# hello'],
+    ['tpl', '# hello'],
+    ['create', 'Daily/2024-05-09.md', '# HELLO'],
     ['open', 'Daily/2024-05-09.md'],
   ]);
 


### PR DESCRIPTION
## Summary
- apply the Templates core plugin when generating new notes
- cover template application in unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683da14201248326903790e07a471ccd