### PR TITLE
Handle template when creating daily notes

### DIFF
--- a/main.js
+++ b/main.js
@@ -316,8 +316,24 @@ class DDSuggest extends obsidian_1.EditorSuggest {
                 const daily = this.app.internalPlugins?.plugins?.["daily-notes"]?.instance?.options;
                 if (daily?.template) {
                     const f = this.app.vault.getAbstractFileByPath(daily.template);
-                    if (f)
-                        tpl = await this.app.vault.read(f);
+                    if (f) {
+                        const templates = this.app.internalPlugins?.plugins?.["templates"]?.instance;
+                        if (templates && typeof templates.parseTemplate === "function") {
+                            try {
+                                tpl = await templates.parseTemplate(f);
+                            }
+                            catch { }
+                        }
+                        else {
+                            tpl = await this.app.vault.read(f);
+                            if (templates && typeof templates.replaceTemplates === "function") {
+                                try {
+                                    tpl = await templates.replaceTemplates(tpl);
+                                }
+                                catch { }
+                            }
+                        }
+                    }
                 }
                 await this.app.vault.create(target, tpl);
                 if (settings.openOnCreate && this.app.workspace?.openLinkText) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -380,7 +380,21 @@ class DDSuggest extends EditorSuggest<string> {
                                 const daily = (this.app as any).internalPlugins?.plugins?.["daily-notes"]?.instance?.options;
                                 if (daily?.template) {
                                         const f = this.app.vault.getAbstractFileByPath(daily.template);
-                                        if (f) tpl = await this.app.vault.read(f as TFile);
+                                        if (f) {
+                                                const templates = (this.app as any).internalPlugins?.plugins?.["templates"]?.instance;
+                                                if (templates && typeof templates.parseTemplate === "function") {
+                                                        try {
+                                                                tpl = await templates.parseTemplate(f);
+                                                        } catch {}
+                                                } else {
+                                                        tpl = await this.app.vault.read(f);
+                                                        if (templates && typeof templates.replaceTemplates === "function") {
+                                                                try {
+                                                                        tpl = await templates.replaceTemplates(tpl);
+                                                                } catch {}
+                                                        }
+                                                }
+                                        }
                                 }
                                 await this.app.vault.create(target, tpl);
                                 if (settings.openOnCreate && this.app.workspace?.openLinkText) {

--- a/test/test.js
+++ b/test/test.js
@@ -176,7 +176,10 @@
     createFolder: (p) => { calls.push(['mkdir', p]); return { then: r => r() }; },
     create: (p, d) => { calls.push(['create', p, d]); return { then: r => r() }; },
   };
-  app.internalPlugins = { plugins: { 'daily-notes': { instance: { options: { template: 'tpl.md' } } } } };
+  app.internalPlugins = { plugins: {
+    'daily-notes': { instance: { options: { template: 'tpl.md' } } },
+    'templates': { instance: { parseTemplate: (f) => { calls.push(['tpl', f.path]); return '# HELLO'; } } }
+  } };
   app.workspace = { openLinkText:(p)=>calls.push(['open', p]) };
   const ed2 = { getLine:()=>'', replaceRange:(t)=>calls.push(['insert', t]) };
   sugg.app = app;
@@ -190,8 +193,8 @@
     ['check', 'Daily'],
     ['mkdir', 'Daily'],
     ['check', 'tpl.md'],
-    ['read', 'tpl.md'],
-    ['create', 'Daily/2024-05-09.md', '# hello'],
+    ['tpl', 'tpl.md'],
+    ['create', 'Daily/2024-05-09.md', '# HELLO'],
     ['open', 'Daily/2024-05-09.md'],
   ]);
 


### PR DESCRIPTION
## Summary
- properly apply daily note template via the Templates core plugin
- update the unit test to cover the new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683da14201248326903790e07a471ccd