### PR TITLE
Fix daily note creation to use system template

### DIFF
--- a/main.js
+++ b/main.js
@@ -313,7 +313,7 @@ class DDSuggest extends obsidian_1.EditorSuggest {
                     await this.app.vault.createFolder(folder);
                 }
                 let tpl = "";
-                const daily = this.app.internalPlugins?.plugins?.["daily-notes"]?.instance?.options;
+                const daily = this.plugin.getDailySettings();
                 if (daily?.template) {
                     const f = this.app.vault.getAbstractFileByPath(daily.template);
                     if (f)
@@ -350,8 +350,18 @@ class DDSuggest extends obsidian_1.EditorSuggest {
  */
 class DynamicDates extends obsidian_1.Plugin {
     settings = DEFAULT_SETTINGS;
+    getDailySettings() {
+        const mc = this.app.metadataCache;
+        if (mc && typeof mc.getDailyNoteSettings === "function") {
+            try {
+                return mc.getDailyNoteSettings();
+            }
+            catch { }
+        }
+        return this.app.internalPlugins?.plugins?.["daily-notes"]?.instance?.options || {};
+    }
     getDailyFolder() {
-        const daily = this.app.internalPlugins?.plugins?.["daily-notes"]?.instance?.options;
+        const daily = this.getDailySettings();
         return daily?.folder || "";
     }
     allPhrases() {
@@ -385,7 +395,7 @@ class DynamicDates extends obsidian_1.Plugin {
     }
     async loadSettings() {
         this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
-        const daily = this.app.internalPlugins?.plugins?.["daily-notes"]?.instance?.options;
+        const daily = this.getDailySettings();
         if (daily && !this.settings.dateFormat)
             this.settings.dateFormat = daily.format;
         if (!this.settings.customDates)

--- a/src/main.ts
+++ b/src/main.ts
@@ -377,7 +377,7 @@ class DDSuggest extends EditorSuggest<string> {
                                         await this.app.vault.createFolder(folder);
                                 }
                                 let tpl = "";
-                                const daily = (this.app as any).internalPlugins?.plugins?.["daily-notes"]?.instance?.options;
+                                const daily = this.plugin.getDailySettings();
                                 if (daily?.template) {
                                         const f = this.app.vault.getAbstractFileByPath(daily.template);
                                         if (f) tpl = await this.app.vault.read(f as TFile);
@@ -417,8 +417,18 @@ class DDSuggest extends EditorSuggest<string> {
 export default class DynamicDates extends Plugin {
         settings: DDSettings = DEFAULT_SETTINGS;
 
+        getDailySettings(): any {
+                const mc = (this.app as any).metadataCache;
+                if (mc && typeof mc.getDailyNoteSettings === "function") {
+                        try {
+                                return mc.getDailyNoteSettings();
+                        } catch {}
+                }
+                return (this.app as any).internalPlugins?.plugins?.["daily-notes"]?.instance?.options || {};
+        }
+
         getDailyFolder(): string {
-                const daily = (this.app as any).internalPlugins?.plugins?.["daily-notes"]?.instance?.options;
+                const daily = this.getDailySettings();
                 return daily?.folder || "";
         }
 
@@ -456,7 +466,7 @@ export default class DynamicDates extends Plugin {
 
         async loadSettings() {
                 this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
-                const daily = (this.app as any).internalPlugins?.plugins?.["daily-notes"]?.instance?.options;
+                const daily = this.getDailySettings();
                 if (daily && !this.settings.dateFormat) this.settings.dateFormat = daily.format;
                 if (!this.settings.customDates) this.settings.customDates = {};
                 (phraseToMoment as any).customDates = Object.fromEntries(Object.entries(this.settings.customDates).map(([k,v]) => [k.toLowerCase(), v]));

--- a/test/test.js
+++ b/test/test.js
@@ -117,7 +117,7 @@
   /* ------------------------------------------------------------------ */
   /* onTrigger guard rails                                             */
   /* ------------------------------------------------------------------ */
-  const plugin = { settings: { dateFormat: 'YYYY-MM-DD', autoCreate: false, acceptKey:'Tab', noAliasWithShift: true, aliasFormat:'capitalize', openOnCreate:false }, dailyFolder:'', allPhrases: () => PHRASES, getDailyFolder(){ return this.dailyFolder; }, customCanonical(){ return null; } };
+  const plugin = { settings: { dateFormat: 'YYYY-MM-DD', autoCreate: false, acceptKey:'Tab', noAliasWithShift: true, aliasFormat:'capitalize', openOnCreate:false }, dailyFolder:'', allPhrases: () => PHRASES, getDailyFolder(){ return this.dailyFolder; }, getDailySettings(){ return { folder:this.dailyFolder, template:'tpl.md', format:'YYYY-MM-DD' }; }, customCanonical(){ return null; } };
   const app = { vault: {} };
   const sugg = new DDSuggest(app, plugin);
 
@@ -176,8 +176,7 @@
     createFolder: (p) => { calls.push(['mkdir', p]); return { then: r => r() }; },
     create: (p, d) => { calls.push(['create', p, d]); return { then: r => r() }; },
   };
-  app.internalPlugins = { plugins: { 
-    'daily-notes': { instance: { options: { template: 'tpl.md' } } },
+  app.internalPlugins = { plugins: {
     'templates': { instance: { parseTemplate: (t) => { calls.push(['tpl', t]); return t.toUpperCase(); } } }
   } };
   app.workspace = { openLinkText:(p)=>calls.push(['open', p]) };
@@ -236,7 +235,7 @@
   /* ------------------------------------------------------------------ */
   /* onTrigger additional guard rails                                   */
   /* ------------------------------------------------------------------ */
-  const tPlugin = { settings: Object.assign({}, plugin.settings, { autoCreate: false }), dailyFolder:'Daily', allPhrases: () => PHRASES, getDailyFolder(){ return this.dailyFolder; }, customCanonical(){ return null; } };
+  const tPlugin = { settings: Object.assign({}, plugin.settings, { autoCreate: false }), dailyFolder:'Daily', allPhrases: () => PHRASES, getDailyFolder(){ return this.dailyFolder; }, getDailySettings(){ return { folder:this.dailyFolder, template:'tpl.md', format:'YYYY-MM-DD' }; }, customCanonical(){ return null; } };
   const tApp = { vault:{}, workspace:{} };
   const tSugg = new DDSuggest(tApp, tPlugin);
   assert.strictEqual(tSugg.onTrigger({line:0,ch:4}, { getLine:()=> 'next' }, null), null);


### PR DESCRIPTION
## Summary
- add `getDailySettings()` helper to read Obsidian daily-note settings
- use it when loading defaults and when auto‑creating notes
- update tests for the new helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683da3ae9ec88326b6025eb29fa120d0