### PR TITLE
Fix capitalization when using suggestions

### DIFF
--- a/main.js
+++ b/main.js
@@ -282,10 +282,18 @@ class DDSuggest extends obsidian_1.EditorSuggest {
                     alias = phraseWords
                         .map((w, i) => {
                         const t = typedWords[i];
-                        if (t &&
-                            t.length === w.length &&
-                            t.toLowerCase() === w.toLowerCase()) {
-                            return isProperNoun(w) ? properCase(w) : t;
+                        if (t) {
+                            // exact match preserves user casing
+                            if (t.length === w.length && t.toLowerCase() === w.toLowerCase()) {
+                                return isProperNoun(w) ? properCase(w) : t;
+                            }
+                            // typed prefix should keep typed characters
+                            if (w.toLowerCase().startsWith(t.toLowerCase())) {
+                                if (isProperNoun(w)) {
+                                    return properCase(w);
+                                }
+                                return t + w.slice(t.length);
+                            }
                         }
                         if (isProperNoun(w))
                             return properCase(w);

--- a/src/main.ts
+++ b/src/main.ts
@@ -335,12 +335,18 @@ class DDSuggest extends EditorSuggest<string> {
                                         alias = phraseWords
                                                 .map((w, i) => {
                                                         const t = typedWords[i];
-                                                        if (
-                                                                t &&
-                                                                t.length === w.length &&
-                                                                t.toLowerCase() === w.toLowerCase()
-                                                        ) {
-                                                                return isProperNoun(w) ? properCase(w) : t;
+                                                        if (t) {
+                                                                // exact match preserves user casing
+                                                                if (t.length === w.length && t.toLowerCase() === w.toLowerCase()) {
+                                                                        return isProperNoun(w) ? properCase(w) : t;
+                                                                }
+                                                                // typed prefix should keep typed characters
+                                                                if (w.toLowerCase().startsWith(t.toLowerCase())) {
+                                                                        if (isProperNoun(w)) {
+                                                                                return properCase(w);
+                                                                        }
+                                                                        return t + w.slice(t.length);
+                                                                }
                                                         }
                                                         if (isProperNoun(w)) return properCase(w);
                                                         if (["last", "next"].includes(w.toLowerCase()) && t)

--- a/test/test.js
+++ b/test/test.js
@@ -135,7 +135,7 @@
   const editor = { getLine:()=>'', replaceRange:(t)=>inserted.push(t) };
   sugg.context = { editor, start:{line:0,ch:0}, end:{line:0,ch:3}, query:'tom' };
   sugg.selectSuggestion('2024-05-09', new KeyboardEvent({ shiftKey:false, key:'Tab' }));
-  assert.strictEqual(inserted.pop(), '[[2024-05-09|Tomorrow]]');
+  assert.strictEqual(inserted.pop(), '[[2024-05-09|tomorrow]]');
 
   sugg.context = { editor, start:{line:0,ch:0}, end:{line:0,ch:3}, query:'tom' };
   sugg.selectSuggestion('2024-05-09', new KeyboardEvent({ shiftKey:true, key:'Tab' }));
@@ -227,7 +227,7 @@
   ev1.preventDefault = () => { called1 = true; };
   tSugg.selectSuggestion('2024-05-09', ev1);
   assert.ok(called1);
-  assert.strictEqual(inserted2.pop(), '[[Daily/2024-05-09|Tomorrow]]');
+  assert.strictEqual(inserted2.pop(), '[[Daily/2024-05-09|tomorrow]]');
 
   const ev2 = new KeyboardEvent({ key:'Enter', shiftKey:true });
   let called2 = false;


### PR DESCRIPTION
## Summary
- ensure suggestions preserve the user's typed casing when aliasFormat is "capitalize"
- update unit tests for the new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683db14831d483269693b89e4ff041cf