### PR TITLE
Add year parsing support

### DIFF
--- a/main.js
+++ b/main.js
@@ -55,7 +55,10 @@ function properCase(word) {
 }
 function needsYearAlias(phrase) {
     const lower = phrase.toLowerCase().trim();
-    return /^(?:last|next)\s+(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+\d{1,2}(?:st|nd|rd|th)?$/.test(lower);
+    if (/^(?:last|next)\s+(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+\d{1,2}(?:st|nd|rd|th)?$/.test(lower)) {
+        return true;
+    }
+    return /^(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+\d{1,2}(?:st|nd|rd|th)?(?:,)?\s*\d{2,4}$/.test(lower);
 }
 const PHRASES = BASE_WORDS.flatMap((w) => WEEKDAYS.includes(w) ? [w, `last ${w}`, `next ${w}`] : [w]);
 /**
@@ -97,6 +100,25 @@ function phraseToMoment(phrase) {
         const n = parseInt(ago[1]);
         if (!isNaN(n))
             return now.clone().subtract(n * (ago[2].startsWith('week') ? 7 : 1), "day");
+    }
+    const mdy = lower.match(/^(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+(\d{1,2})(?:st|nd|rd|th)?(?:,)?\s*(\d{2,4})$/i);
+    if (mdy) {
+        let monthName = mdy[1];
+        if (monthName.length <= 3) {
+            const idx = ["jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec"].indexOf(monthName.slice(0, 3));
+            monthName = ["january", "february", "march", "april", "may", "june", "july", "august", "september", "october", "november", "december"][idx];
+        }
+        const dayNum = parseInt(mdy[2]);
+        let yearNum = parseInt(mdy[3]);
+        if (!isNaN(dayNum) && !isNaN(yearNum)) {
+            if (yearNum < 100)
+                yearNum += 2000;
+            const idx = MONTHS.indexOf(monthName.toLowerCase());
+            const target = (0, obsidian_1.moment)(new Date(yearNum, idx, dayNum));
+            if (!target.isValid())
+                return null;
+            return target;
+        }
     }
     const lastMd = lower.match(/^last\s+(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+(\d{1,2}\w*)$/i);
     if (lastMd) {

--- a/test/test.js
+++ b/test/test.js
@@ -122,6 +122,10 @@
   assert.strictEqual(fmt(phraseToMoment('jan 1')), '2025-01-01');
   assert.strictEqual(fmt(phraseToMoment('last may 1')), '2024-05-01');
   assert.strictEqual(fmt(phraseToMoment('the 24th')), '2024-05-24');
+  assert.strictEqual(fmt(phraseToMoment('may 1, 2023')), '2023-05-01');
+  assert.strictEqual(fmt(phraseToMoment('may 1st, 2023')), '2023-05-01');
+  assert.strictEqual(fmt(phraseToMoment('may 1, 23')), '2023-05-01');
+  assert.strictEqual(fmt(phraseToMoment('may 1st, 23')), '2023-05-01');
 
   /* ------------------------------------------------------------------ */
   /* onTrigger guard rails                                             */
@@ -200,6 +204,8 @@
   lf.settings.aliasFormat = 'date';
   assert.strictEqual(lf.linkForPhrase('tomorrow'), '[[Journal/2024-05-09|May 9th]]');
   assert.strictEqual(lf.linkForPhrase('last may 1'), '[[Journal/2024-05-01|May 1st, 2024]]');
+  assert.strictEqual(lf.linkForPhrase('may 1, 2023'), '[[Journal/2023-05-01|May 1st, 2023]]');
+  assert.strictEqual(lf.linkForPhrase('may 1st, 23'), '[[Journal/2023-05-01|May 1st, 2023]]');
   assert.strictEqual(lf.linkForPhrase('nonsense'), null);
 
   /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## Summary
- detect year in date phrases like `May 1, 2023`
- include year when formatting aliases
- test explicit year parsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683db7917ff08326aee696063c3825dd