### PR TITLE
Add Node CI workflow

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,0 +1,18 @@
+name: Node CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -33,3 +33,10 @@ npm run zip
 ```
 
 Upload the generated `dynamic-dates-<version>.zip` file when creating a GitHub release.
+
+## Continuous Integration
+
+This project uses [GitHub Actions](https://github.com/features/actions) to run
+`npm test` whenever changes are pushed or pull requests are opened against the
+`main` branch. The workflow configuration lives in
+`.github/workflows/node.yml`.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run `npm test`
- mention CI setup in the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683dca8726408326bd199fc72f67bbd1