### PR TITLE
Improve custom phrase lookup

### DIFF
--- a/main.js
+++ b/main.js
@@ -425,6 +425,14 @@ class DDSuggest extends obsidian_1.EditorSuggest {
  */
 class DynamicDates extends obsidian_1.Plugin {
     settings = DEFAULT_SETTINGS;
+    customMap = {};
+    refreshCustomMap() {
+        this.customMap = {};
+        for (const key of Object.keys(this.settings.customDates || {})) {
+            this.customMap[key.toLowerCase()] = key;
+        }
+        phraseToMoment.customDates = Object.fromEntries(Object.entries(this.settings.customDates || {}).map(([k, v]) => [k.toLowerCase(), v]));
+    }
     getDailySettings() {
         const mc = this.app.metadataCache;
         if (mc && typeof mc.getDailyNoteSettings === "function") {
@@ -444,12 +452,7 @@ class DynamicDates extends obsidian_1.Plugin {
     }
     /** Return the canonical form for a custom phrase, if any. */
     customCanonical(lower) {
-        lower = lower.toLowerCase();
-        for (const p of Object.keys(this.settings.customDates || {})) {
-            if (p.toLowerCase() === lower)
-                return p;
-        }
-        return null;
+        return this.customMap[lower.toLowerCase()] || null;
     }
     async onload() {
         await this.loadSettings();
@@ -475,11 +478,11 @@ class DynamicDates extends obsidian_1.Plugin {
             this.settings.dateFormat = daily.format;
         if (!this.settings.customDates)
             this.settings.customDates = {};
-        phraseToMoment.customDates = Object.fromEntries(Object.entries(this.settings.customDates).map(([k, v]) => [k.toLowerCase(), v]));
+        this.refreshCustomMap();
     }
     async saveSettings() {
         await this.saveData(this.settings);
-        phraseToMoment.customDates = Object.fromEntries(Object.entries(this.settings.customDates || {}).map(([k, v]) => [k.toLowerCase(), v]));
+        this.refreshCustomMap();
     }
     linkForPhrase(phrase) {
         const m = phraseToMoment(phrase);

--- a/test/test.js
+++ b/test/test.js
@@ -270,6 +270,21 @@
   assert.strictEqual(fmt(phraseToMoment('quarter end')), '2024-09-30');
 
   /* ------------------------------------------------------------------ */
+  /* customCanonical cache behaviour                                    */
+  /* ------------------------------------------------------------------ */
+  const cachePlugin = new DynamicDates();
+  cachePlugin.loadData = async () => ({ customDates: { 'Leap Day': '02-29' } });
+  cachePlugin.saveData = async () => {};
+  await cachePlugin.loadSettings();
+  assert.strictEqual(cachePlugin.customMap['leap day'], 'Leap Day');
+  assert.strictEqual(cachePlugin.customCanonical('leap day'), 'Leap Day');
+  cachePlugin.settings.customDates['Quarter End'] = '09-30';
+  // customMap not refreshed yet so lookup should fail
+  assert.strictEqual(cachePlugin.customCanonical('quarter end'), null);
+  await cachePlugin.saveSettings();
+  assert.strictEqual(cachePlugin.customCanonical('quarter end'), 'Quarter End');
+
+  /* ------------------------------------------------------------------ */
   /* custom dates feature                                               */
   /* ------------------------------------------------------------------ */
   phraseToMoment.customDates = { 'fall start': '08-22' };


### PR DESCRIPTION
## Summary
- cache custom dates by lowercase phrase
- refresh custom date cache when settings load or save
- tweak `customCanonical` to rely on the cache
- test cache behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683df29ab61c83268e31b98651479f6e