### PR TITLE
Enable Tab key acceptance

### DIFF
--- a/src/obsidian.d.ts
+++ b/src/obsidian.d.ts
@@ -18,6 +18,7 @@ declare module "obsidian" {
     export class Plugin {
         app: App;
         registerEditorSuggest(s: EditorSuggest<any>): void;
+        registerDomEvent(el: any, type: string, cb: (ev: any) => any): void;
         addSettingTab(tab: PluginSettingTab): void;
         addCommand(cmd: any): void;
         loadData(): Promise<any>;


### PR DESCRIPTION
## Summary
- keep track of last suggestions in `DDSuggest`
- add `onKeyDown` to handle Tab key
- register DOM keydown handler for suggestions
- update type stubs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683df62f0a3c8326a813ae2f48f7ade3