### PR TITLE
Fix shift key plain link option

### DIFF
--- a/main.js
+++ b/main.js
@@ -417,11 +417,10 @@ class DDSuggest extends obsidian_1.EditorSuggest {
         this.close();
     }
     onKeyDown(ev) {
-        if (ev.key === 'Tab' && this.plugin.settings.acceptKey === 'Tab' && this.context) {
+        if (this.context && ev.key === this.plugin.settings.acceptKey) {
             if (typeof ev.preventDefault === 'function')
                 ev.preventDefault();
-            const list = this._last;
-            const value = list[0];
+            const value = this._last[0];
             if (value)
                 this.selectSuggestion(value, ev);
             return true;

--- a/src/main.ts
+++ b/src/main.ts
@@ -476,10 +476,9 @@ class DDSuggest extends EditorSuggest<string> {
         }
 
         onKeyDown(ev: KeyboardEvent): boolean {
-                if (ev.key === 'Tab' && this.plugin.settings.acceptKey === 'Tab' && this.context) {
+                if (this.context && ev.key === this.plugin.settings.acceptKey) {
                         if (typeof ev.preventDefault === 'function') ev.preventDefault();
-                        const list = this._last;
-                        const value = list[0];
+                        const value = this._last[0];
                         if (value) this.selectSuggestion(value, ev);
                         return true;
                 }


### PR DESCRIPTION
## Summary
- handle `Enter` as an accept key when detecting Shift modifier

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683df8476f3c8326987111fc2354c922