### PR TITLE
Add US holiday recognition

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Dynamic Dates is an Obsidian plugin that turns natural language phrases such as 
 - Insert a wiki link to your daily note using <kbd>Tab</kbd> or <kbd>Enter</kbd>.
 - Define your own phrases (e.g. `Mid Year`) that map to a specific calendar date.
 - Convert an entire note's text to date links via the `Convert natural-language dates` command.
+- Built-in awareness of common U.S. holidays like **Memorial Day** and **Thanksgiving**.
 
 ## Building
 

--- a/test/test.js
+++ b/test/test.js
@@ -126,6 +126,11 @@
   assert.strictEqual(fmt(phraseToMoment('may 1st, 2023')), '2023-05-01');
   assert.strictEqual(fmt(phraseToMoment('may 1, 23')), '2023-05-01');
   assert.strictEqual(fmt(phraseToMoment('may 1st, 23')), '2023-05-01');
+  assert.strictEqual(fmt(phraseToMoment('memorial day')), '2024-05-27');
+  assert.strictEqual(fmt(phraseToMoment('labor day')), '2024-09-02');
+  assert.strictEqual(fmt(phraseToMoment('thanksgiving')), '2024-11-28');
+  assert.strictEqual(fmt(phraseToMoment('mlk day')), '2025-01-20');
+  assert.strictEqual(fmt(phraseToMoment("new year's day")), '2025-01-01');
 
   /* ------------------------------------------------------------------ */
   /* onTrigger guard rails                                             */


### PR DESCRIPTION
## Summary
- support common US holidays in date suggestions
- mention holiday support in README
- test US holiday recognition

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683e0329deb483269f2e084ca3218297