### PR TITLE
Fix holiday capitalization

### DIFF
--- a/main.js
+++ b/main.js
@@ -44,20 +44,6 @@ const MONTHS = [
     "november",
     "december",
 ];
-function isProperNoun(word) {
-    const w = word.toLowerCase();
-    return WEEKDAYS.includes(w) || MONTHS.includes(w);
-}
-function properCase(word) {
-    return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
-}
-function needsYearAlias(phrase) {
-    const lower = phrase.toLowerCase().trim();
-    if (/^(?:last|next)\s+(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+\d{1,2}(?:st|nd|rd|th)?$/.test(lower)) {
-        return true;
-    }
-    return /^(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+\d{1,2}(?:st|nd|rd|th)?(?:,)?\s*\d{2,4}$/.test(lower);
-}
 const HOLIDAY_PHRASES = [
     "new year's day",
     "mlk day",
@@ -74,6 +60,23 @@ const HOLIDAY_PHRASES = [
     "christmas",
     "christmas day",
 ];
+const HOLIDAY_WORDS = Array.from(new Set(HOLIDAY_PHRASES.flatMap((p) => p.split(/\s+/).map((w) => w.toLowerCase()))));
+function isProperNoun(word) {
+    const w = word.toLowerCase();
+    return (WEEKDAYS.includes(w) ||
+        MONTHS.includes(w) ||
+        HOLIDAY_WORDS.includes(w));
+}
+function properCase(word) {
+    return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+}
+function needsYearAlias(phrase) {
+    const lower = phrase.toLowerCase().trim();
+    if (/^(?:last|next)\s+(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+\d{1,2}(?:st|nd|rd|th)?$/.test(lower)) {
+        return true;
+    }
+    return /^(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+\d{1,2}(?:st|nd|rd|th)?(?:,)?\s*\d{2,4}$/.test(lower);
+}
 const PHRASES = BASE_WORDS.flatMap((w) => WEEKDAYS.includes(w) ? [w, `last ${w}`, `next ${w}`] : [w]).concat(HOLIDAY_PHRASES);
 /**
  * Convert a natural-language phrase into a moment date instance.

--- a/src/main.ts
+++ b/src/main.ts
@@ -72,23 +72,6 @@ const MONTHS = [
         "december",
 ];
 
-function isProperNoun(word: string): boolean {
-        const w = word.toLowerCase();
-        return WEEKDAYS.includes(w) || MONTHS.includes(w);
-}
-
-function properCase(word: string): string {
-        return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
-}
-
-function needsYearAlias(phrase: string): boolean {
-        const lower = phrase.toLowerCase().trim();
-        if (/^(?:last|next)\s+(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+\d{1,2}(?:st|nd|rd|th)?$/.test(lower)) {
-                return true;
-        }
-        return /^(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+\d{1,2}(?:st|nd|rd|th)?(?:,)?\s*\d{2,4}$/.test(lower);
-}
-
 const HOLIDAY_PHRASES = [
         "new year's day",
         "mlk day",
@@ -105,6 +88,36 @@ const HOLIDAY_PHRASES = [
         "christmas",
         "christmas day",
 ];
+
+const HOLIDAY_WORDS = Array.from(
+        new Set(
+                HOLIDAY_PHRASES.flatMap((p) =>
+                        p.split(/\s+/).map((w) => w.toLowerCase()),
+                ),
+        ),
+);
+
+function isProperNoun(word: string): boolean {
+        const w = word.toLowerCase();
+        return (
+                WEEKDAYS.includes(w) ||
+                MONTHS.includes(w) ||
+                HOLIDAY_WORDS.includes(w)
+        );
+}
+
+function properCase(word: string): string {
+        return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+}
+
+function needsYearAlias(phrase: string): boolean {
+        const lower = phrase.toLowerCase().trim();
+        if (/^(?:last|next)\s+(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+\d{1,2}(?:st|nd|rd|th)?$/.test(lower)) {
+                return true;
+        }
+        return /^(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+\d{1,2}(?:st|nd|rd|th)?(?:,)?\s*\d{2,4}$/.test(lower);
+}
+
 const PHRASES = BASE_WORDS.flatMap((w) =>
         WEEKDAYS.includes(w) ? [w, `last ${w}`, `next ${w}`] : [w],
 ).concat(HOLIDAY_PHRASES);

--- a/test/test.js
+++ b/test/test.js
@@ -12,7 +12,7 @@
   if (!pluginSrc) throw new Error('DynamicDates class not found');
   const settingsSrc = code.match(/const DEFAULT_SETTINGS =[^]*?};/);
   if (!settingsSrc) throw new Error('DEFAULT_SETTINGS not found');
-  const helpersSrc = code.match(/function isProperNoun[^]*?}\nfunction properCase[^]*?}\nfunction needsYearAlias[^]*?\n\}/);
+  const helpersSrc = code.match(/const HOLIDAY_PHRASES[^]*?const HOLIDAY_WORDS[^]*?function isProperNoun[^]*?}\nfunction properCase[^]*?}\nfunction needsYearAlias[^]*?\n\}/);
   if (!helpersSrc) throw new Error('helper functions not found');
 
   /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## Summary
- capitalize holiday phrases when inserting suggestions and links
- adjust helper regex in tests for new holiday constants

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683e058ec6b08326a4407aa152f5fe1f