### PR TITLE
Improve holiday parsing with last & year modifiers

### DIFF
--- a/main.js
+++ b/main.js
@@ -126,12 +126,33 @@ function phraseToMoment(phrase) {
             return m;
         }
     }
-    if (lower in HOLIDAYS) {
-        const calc = HOLIDAYS[lower];
-        let m = calc(now.year());
-        if (m.isBefore(now, "day"))
-            m = calc(now.year() + 1);
-        return m;
+    for (const [name, calc] of Object.entries(HOLIDAYS)) {
+        if (lower === name) {
+            let m = calc(now.year());
+            if (m.isBefore(now, "day"))
+                m = calc(now.year() + 1);
+            return m;
+        }
+        if (lower === `last ${name}`) {
+            let m = calc(now.year());
+            if (!m.isBefore(now, "day"))
+                m = calc(now.year() - 1);
+            return m;
+        }
+        if (lower === `next ${name}`) {
+            let m = calc(now.year());
+            if (!m.isAfter(now, "day"))
+                m = calc(now.year() + 1);
+            return m;
+        }
+        const re = new RegExp(`^${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?:\\s+of)?\\s+(\\d{2,4})$`);
+        const matchYear = lower.match(re);
+        if (matchYear) {
+            let y = parseInt(matchYear[1]);
+            if (y < 100)
+                y += 2000;
+            return calc(y);
+        }
     }
     if (lower === "today")
         return now;

--- a/src/main.ts
+++ b/src/main.ts
@@ -173,11 +173,29 @@ function phraseToMoment(phrase: string): moment.Moment | null {
                 }
         }
 
-        if (lower in HOLIDAYS) {
-                const calc = HOLIDAYS[lower];
-                let m = calc(now.year());
-                if (m.isBefore(now, "day")) m = calc(now.year() + 1);
-                return m;
+        for (const [name, calc] of Object.entries(HOLIDAYS)) {
+                if (lower === name) {
+                        let m = calc(now.year());
+                        if (m.isBefore(now, "day")) m = calc(now.year() + 1);
+                        return m;
+                }
+                if (lower === `last ${name}`) {
+                        let m = calc(now.year());
+                        if (!m.isBefore(now, "day")) m = calc(now.year() - 1);
+                        return m;
+                }
+                if (lower === `next ${name}`) {
+                        let m = calc(now.year());
+                        if (!m.isAfter(now, "day")) m = calc(now.year() + 1);
+                        return m;
+                }
+                const re = new RegExp(`^${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?:\\s+of)?\\s+(\\d{2,4})$`);
+                const matchYear = lower.match(re);
+                if (matchYear) {
+                        let y = parseInt(matchYear[1]);
+                        if (y < 100) y += 2000;
+                        return calc(y);
+                }
         }
 
         if (lower === "today") return now;

--- a/test/test.js
+++ b/test/test.js
@@ -131,6 +131,9 @@
   assert.strictEqual(fmt(phraseToMoment('thanksgiving')), '2024-11-28');
   assert.strictEqual(fmt(phraseToMoment('mlk day')), '2025-01-20');
   assert.strictEqual(fmt(phraseToMoment("new year's day")), '2025-01-01');
+  assert.strictEqual(fmt(phraseToMoment('last christmas')), '2023-12-25');
+  assert.strictEqual(fmt(phraseToMoment('christmas 24')), '2024-12-25');
+  assert.strictEqual(fmt(phraseToMoment('christmas of 2025')), '2025-12-25');
 
   /* ------------------------------------------------------------------ */
   /* onTrigger guard rails                                             */


### PR DESCRIPTION
## Summary
- support `last`/`next` qualifiers and explicit year for holidays
- add regression tests for these holiday cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683e0bac0e308326b6b712a8d8ebaedf