### PR TITLE
Fix last holiday calculation

### DIFF
--- a/main.js
+++ b/main.js
@@ -126,12 +126,27 @@ function phraseToMoment(phrase) {
             return m;
         }
     }
-    if (lower in HOLIDAYS) {
-        const calc = HOLIDAYS[lower];
-        let m = calc(now.year());
-        if (m.isBefore(now, "day"))
-            m = calc(now.year() + 1);
-        return m;
+    for (const [name, calc] of Object.entries(HOLIDAYS)) {
+        if (lower === name) {
+            let m = calc(now.year());
+            if (m.isBefore(now, "day"))
+                m = calc(now.year() + 1);
+            return m;
+        }
+        if (lower === `last ${name}`) {
+            return calc(now.year() - 1);
+        }
+        if (lower === `next ${name}`) {
+            return calc(now.year() + 1);
+        }
+        const re = new RegExp(`^${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?:\\s+of)?\\s+(\\d{2,4})$`);
+        const matchYear = lower.match(re);
+        if (matchYear) {
+            let y = parseInt(matchYear[1]);
+            if (y < 100)
+                y += 2000;
+            return calc(y);
+        }
     }
     if (lower === "today")
         return now;

--- a/src/main.ts
+++ b/src/main.ts
@@ -173,11 +173,25 @@ function phraseToMoment(phrase: string): moment.Moment | null {
                 }
         }
 
-        if (lower in HOLIDAYS) {
-                const calc = HOLIDAYS[lower];
-                let m = calc(now.year());
-                if (m.isBefore(now, "day")) m = calc(now.year() + 1);
-                return m;
+        for (const [name, calc] of Object.entries(HOLIDAYS)) {
+                if (lower === name) {
+                        let m = calc(now.year());
+                        if (m.isBefore(now, "day")) m = calc(now.year() + 1);
+                        return m;
+                }
+                if (lower === `last ${name}`) {
+                        return calc(now.year() - 1);
+                }
+                if (lower === `next ${name}`) {
+                        return calc(now.year() + 1);
+                }
+                const re = new RegExp(`^${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?:\\s+of)?\\s+(\\d{2,4})$`);
+                const matchYear = lower.match(re);
+                if (matchYear) {
+                        let y = parseInt(matchYear[1]);
+                        if (y < 100) y += 2000;
+                        return calc(y);
+                }
         }
 
         if (lower === "today") return now;

--- a/test/test.js
+++ b/test/test.js
@@ -131,6 +131,13 @@
   assert.strictEqual(fmt(phraseToMoment('thanksgiving')), '2024-11-28');
   assert.strictEqual(fmt(phraseToMoment('mlk day')), '2025-01-20');
   assert.strictEqual(fmt(phraseToMoment("new year's day")), '2025-01-01');
+  assert.strictEqual(fmt(phraseToMoment('last christmas')), '2023-12-25');
+  assert.strictEqual(fmt(phraseToMoment('christmas 24')), '2024-12-25');
+  assert.strictEqual(fmt(phraseToMoment('christmas of 2025')), '2025-12-25');
+
+  moment.now = new Date('2024-12-26');
+  assert.strictEqual(fmt(phraseToMoment('last christmas')), '2023-12-25');
+  moment.now = new Date('2024-05-08');
 
   /* ------------------------------------------------------------------ */
   /* onTrigger guard rails                                             */


### PR DESCRIPTION
## Summary
- adjust `last` qualifier logic for holidays to always use the prior year
- update compiled JS and add regression test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683e0bac0e308326b6b712a8d8ebaedf