### PR TITLE
Hide holiday toggles when group disabled

### DIFF
--- a/main.js
+++ b/main.js
@@ -655,16 +655,19 @@ class DDSettingTab extends obsidian_1.PluginSettingTab {
                 .onChange(async (v) => {
                 this.plugin.settings.holidayGroups[g] = v;
                 await this.plugin.saveSettings();
+                this.display();
             }));
-            list.forEach(h => {
-                new obsidian_1.Setting(containerEl)
-                    .setDesc(h)
-                    .addToggle(t => t.setValue(this.plugin.settings.holidayOverrides[h] ?? true)
-                    .onChange(async (v) => {
-                    this.plugin.settings.holidayOverrides[h] = v;
-                    await this.plugin.saveSettings();
-                }));
-            });
+            if (this.plugin.settings.holidayGroups[g] ?? true) {
+                list.forEach(h => {
+                    new obsidian_1.Setting(containerEl)
+                        .setDesc(h)
+                        .addToggle(t => t.setValue(this.plugin.settings.holidayOverrides[h] ?? true)
+                        .onChange(async (v) => {
+                        this.plugin.settings.holidayOverrides[h] = v;
+                        await this.plugin.saveSettings();
+                    }));
+                });
+            }
         });
         containerEl.createEl("h3", { text: "Custom date mappings" });
         new obsidian_1.Setting(containerEl)

--- a/src/main.ts
+++ b/src/main.ts
@@ -749,17 +749,20 @@ class DDSettingTab extends PluginSettingTab {
                                          .onChange(async (v:boolean) => {
                                                  this.plugin.settings.holidayGroups[g] = v;
                                                  await this.plugin.saveSettings();
+                                                 this.display();
                                          }));
-                        list.forEach(h => {
-                                new Setting(containerEl)
-                                        .setDesc(h)
-                                        .addToggle(t =>
-                                                t.setValue(this.plugin.settings.holidayOverrides[h] ?? true)
-                                                 .onChange(async (v:boolean) => {
-                                                         this.plugin.settings.holidayOverrides[h] = v;
-                                                         await this.plugin.saveSettings();
-                                                 }));
-                        });
+                        if (this.plugin.settings.holidayGroups[g] ?? true) {
+                                list.forEach(h => {
+                                        new Setting(containerEl)
+                                                .setDesc(h)
+                                                .addToggle(t =>
+                                                        t.setValue(this.plugin.settings.holidayOverrides[h] ?? true)
+                                                         .onChange(async (v:boolean) => {
+                                                                 this.plugin.settings.holidayOverrides[h] = v;
+                                                                 await this.plugin.saveSettings();
+                                                         }));
+                                });
+                        }
                 });
 
                 (containerEl as any).createEl("h3", { text: "Custom date mappings" });


### PR DESCRIPTION
## Summary
- refresh settings display when holiday group toggle changes
- show individual holiday toggles only when the group is enabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683e6580829c83269ac6668cb001f01c