### PR TITLE
Improve holiday alias support and add new groups

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -83,12 +83,34 @@ function lastWeekdayOfMonth(year: number, month: number, weekday: number) {
 interface HolidayDef {
         group: string;
         calc: (y: number) => moment.Moment;
+        aliases?: string[];
 }
 
-const HOLIDAYS: Record<string, HolidayDef> = {
+function easter(y: number): moment.Moment {
+        const a = y % 19;
+        const b = Math.floor(y / 100);
+        const c = y % 100;
+        const d = Math.floor(b / 4);
+        const e = b % 4;
+        const f = Math.floor((b + 8) / 25);
+        const g = Math.floor((b - f + 1) / 3);
+        const h = (19 * a + b - d - g + 15) % 30;
+        const i = Math.floor(c / 4);
+        const k = c % 4;
+        const l = (32 + 2 * e + 2 * i - h - k) % 7;
+        const m = Math.floor((a + 11 * h + 22 * l) / 451);
+        const month = Math.floor((h + l - 7 * m + 114) / 31) - 1;
+        const day = ((h + l - 7 * m + 114) % 31) + 1;
+        return moment(new Date(y, month, day));
+}
+
+const HOLIDAY_DEFS: Record<string, HolidayDef> = {
         "new year's day": { group: "US Federal Holidays", calc: (y) => moment(new Date(y, 0, 1)) },
-        "mlk day": { group: "US Federal Holidays", calc: (y) => nthWeekdayOfMonth(y, 0, 1, 3) },
-        "martin luther king jr day": { group: "US Federal Holidays", calc: (y) => nthWeekdayOfMonth(y, 0, 1, 3) },
+        "martin luther king jr day": {
+                group: "US Federal Holidays",
+                calc: (y) => nthWeekdayOfMonth(y, 0, 1, 3),
+                aliases: ["mlk day", "martin luther king day"],
+        },
         "presidents day": { group: "US Federal Holidays", calc: (y) => nthWeekdayOfMonth(y, 1, 1, 3) },
         "memorial day": { group: "US Federal Holidays", calc: (y) => lastWeekdayOfMonth(y, 4, 1) },
         "juneteenth": { group: "US Federal Holidays", calc: (y) => moment(new Date(y, 5, 19)) },
@@ -96,16 +118,39 @@ const HOLIDAYS: Record<string, HolidayDef> = {
         "labor day": { group: "US Federal Holidays", calc: (y) => nthWeekdayOfMonth(y, 8, 1, 1) },
         "columbus day": { group: "US Federal Holidays", calc: (y) => nthWeekdayOfMonth(y, 9, 1, 2) },
         "veterans day": { group: "US Federal Holidays", calc: (y) => moment(new Date(y, 10, 11)) },
-        "thanksgiving": { group: "US Federal Holidays", calc: (y) => nthWeekdayOfMonth(y, 10, 4, 4) },
-        "thanksgiving day": { group: "US Federal Holidays", calc: (y) => nthWeekdayOfMonth(y, 10, 4, 4) },
-        "christmas": { group: "US Federal Holidays", calc: (y) => moment(new Date(y, 11, 25)) },
-        "christmas day": { group: "US Federal Holidays", calc: (y) => moment(new Date(y, 11, 25)) },
+        "thanksgiving": {
+                group: "US Federal Holidays",
+                calc: (y) => nthWeekdayOfMonth(y, 10, 4, 4),
+                aliases: ["thanksgiving day"],
+        },
+        "christmas": {
+                group: "US Federal Holidays",
+                calc: (y) => moment(new Date(y, 11, 25)),
+                aliases: ["christmas day"],
+        },
+
+        // US Cultural Holidays
+        "valentine's day": { group: "US Cultural Holidays", calc: (y) => moment(new Date(y, 1, 14)) },
+        "halloween": { group: "US Cultural Holidays", calc: (y) => moment(new Date(y, 9, 31)) },
+        "new year's eve": { group: "US Cultural Holidays", calc: (y) => moment(new Date(y, 11, 31)) },
+
+        // Christian Holidays
+        "easter": { group: "Christian Holidays", calc: (y) => easter(y), aliases: ["easter sunday"] },
+        "good friday": { group: "Christian Holidays", calc: (y) => easter(y).subtract(2, "day") },
+        "ash wednesday": { group: "Christian Holidays", calc: (y) => easter(y).subtract(46, "day") },
 };
 
+interface HolidayEntry extends HolidayDef { canonical: string; }
+
+const HOLIDAYS: Record<string, HolidayEntry> = {} as Record<string, HolidayEntry>;
 const GROUP_HOLIDAYS: Record<string, string[]> = {};
-for (const [name, def] of Object.entries(HOLIDAYS)) {
+for (const [canon, def] of Object.entries(HOLIDAY_DEFS)) {
         if (!GROUP_HOLIDAYS[def.group]) GROUP_HOLIDAYS[def.group] = [];
-        GROUP_HOLIDAYS[def.group].push(name);
+        GROUP_HOLIDAYS[def.group].push(canon);
+        HOLIDAYS[canon] = { ...def, canonical: canon };
+        for (const a of def.aliases || []) {
+                HOLIDAYS[a] = { group: def.group, calc: def.calc, canonical: canon };
+        }
 }
 
 const HOLIDAY_PHRASES = Object.keys(HOLIDAYS);
@@ -119,10 +164,13 @@ const HOLIDAY_WORDS = Array.from(
 );
 
 function holidayEnabled(name: string): boolean {
+        const entry = HOLIDAYS[name];
+        if (!entry) return true;
+        const canonical = entry.canonical;
         const overrides: Record<string, boolean> = (phraseToMoment as any).holidayOverrides || {};
-        if (name in overrides) return overrides[name];
+        if (canonical in overrides) return overrides[canonical];
         const groups: Record<string, boolean> = (phraseToMoment as any).holidayGroups || {};
-        const g = HOLIDAYS[name]?.group;
+        const g = entry.group;
         if (g && g in groups) return groups[g];
         return true;
 }
@@ -625,10 +673,11 @@ export default class DynamicDates extends Plugin {
         }
 
         isHolidayEnabled(name: string): boolean {
-                const override = this.settings.holidayOverrides?.[name];
+                const entry = HOLIDAYS[name];
+                if (!entry) return false;
+                const override = this.settings.holidayOverrides?.[entry.canonical];
                 if (typeof override === 'boolean') return override;
-                const g = HOLIDAYS[name]?.group;
-                const grp = this.settings.holidayGroups?.[g];
+                const grp = this.settings.holidayGroups?.[entry.group];
                 return grp !== false;
         }
 

--- a/test/test.js
+++ b/test/test.js
@@ -131,10 +131,13 @@
   assert.strictEqual(fmt(phraseToMoment('labor day')), '2024-09-02');
   assert.strictEqual(fmt(phraseToMoment('thanksgiving')), '2024-11-28');
   assert.strictEqual(fmt(phraseToMoment('mlk day')), '2025-01-20');
+  assert.strictEqual(fmt(phraseToMoment('martin luther king day')), '2025-01-20');
   assert.strictEqual(fmt(phraseToMoment("new year's day")), '2025-01-01');
   assert.strictEqual(fmt(phraseToMoment('last christmas')), '2023-12-25');
   assert.strictEqual(fmt(phraseToMoment('christmas 24')), '2024-12-25');
   assert.strictEqual(fmt(phraseToMoment('christmas of 2025')), '2025-12-25');
+  assert.strictEqual(fmt(phraseToMoment("valentine's day")), '2025-02-14');
+  assert.strictEqual(fmt(phraseToMoment('easter')), '2025-04-20');
 
   // holiday toggles
   phraseToMoment.holidayGroups = { 'US Federal Holidays': false };
@@ -150,6 +153,16 @@
   assert.strictEqual(fmt(phraseToMoment('memorial day')), '2024-05-27');
   phraseToMoment.holidayGroups = { 'US Federal Holidays': true };
   phraseToMoment.holidayOverrides = {};
+
+  phraseToMoment.holidayGroups = { 'US Cultural Holidays': false };
+  assert.strictEqual(phraseToMoment("valentine's day"), null);
+  phraseToMoment.holidayGroups = { 'US Cultural Holidays': true };
+  assert.strictEqual(fmt(phraseToMoment("valentine's day")), '2025-02-14');
+
+  phraseToMoment.holidayGroups = { 'Christian Holidays': false };
+  assert.strictEqual(phraseToMoment('easter'), null);
+  phraseToMoment.holidayGroups = { 'Christian Holidays': true };
+  assert.strictEqual(fmt(phraseToMoment('easter')), '2025-04-20');
 
   /* ------------------------------------------------------------------ */
   /* onTrigger guard rails                                             */
@@ -330,11 +343,11 @@
   const hPlugin = new DynamicDates();
   hPlugin.settings = Object.assign({}, plugin.settings, {
     holidayGroups: { 'US Federal Holidays': true },
-    holidayOverrides: { 'mlk day': false }
+    holidayOverrides: { 'martin luther king jr day': false }
   });
   hPlugin.refreshHolidayMap();
   assert.ok(!hPlugin.allPhrases().includes('mlk day'));
-  hPlugin.settings.holidayOverrides['mlk day'] = true;
+  hPlugin.settings.holidayOverrides['martin luther king jr day'] = true;
   hPlugin.refreshHolidayMap();
   assert.ok(hPlugin.allPhrases().includes('mlk day'));
 


### PR DESCRIPTION
## Summary
- support holiday aliases through canonical mapping
- add cultural and Christian holidays
- update plugin logic and tests for new groups

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683e6a03b2708326a326490d7588e77a