### PR TITLE
Add Canadian & UK holiday support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Dynamic Dates is an Obsidian plugin that turns natural language phrases such as 
 - Insert a wiki link to your daily note using <kbd>Tab</kbd> or <kbd>Enter</kbd>.
 - Define your own phrases (e.g. `Mid Year`) that map to a specific calendar date.
 - Convert an entire note's text to date links via the `Convert natural-language dates` command.
-- Built-in awareness of common U.S. holidays like **Memorial Day** and **Thanksgiving**, with settings to enable or disable entire holiday groups or individual holidays.
+- Built-in awareness of holidays across multiple regions, including U.S., Canadian and U.K. observances, with settings to enable or disable entire holiday groups or individual holidays.
 
 ## Building
 

--- a/main.js
+++ b/main.js
@@ -49,6 +49,11 @@ function lastWeekdayOfMonth(year, month, weekday) {
     const diff = (last.weekday() - weekday + 7) % 7;
     return last.subtract(diff, "day");
 }
+function weekdayOnOrBefore(year, month, day, weekday) {
+    const target = (0, obsidian_1.moment)(new Date(year, month, day));
+    const diff = (target.weekday() - weekday + 7) % 7;
+    return target.subtract(diff, "day");
+}
 function easter(y) {
     const a = y % 19;
     const b = Math.floor(y / 100);
@@ -98,6 +103,16 @@ const HOLIDAY_DEFS = {
     "easter": { group: "Christian Holidays", calc: (y) => easter(y), aliases: ["easter sunday"] },
     "good friday": { group: "Christian Holidays", calc: (y) => easter(y).subtract(2, "day") },
     "ash wednesday": { group: "Christian Holidays", calc: (y) => easter(y).subtract(46, "day") },
+    // Canadian Federal Holidays
+    "canada day": { group: "Canadian Federal Holidays", calc: (y) => (0, obsidian_1.moment)(new Date(y, 6, 1)) },
+    "victoria day": { group: "Canadian Federal Holidays", calc: (y) => weekdayOnOrBefore(y, 4, 24, 1) },
+    "canadian thanksgiving": {
+        group: "Canadian Federal Holidays",
+        calc: (y) => nthWeekdayOfMonth(y, 9, 1, 2),
+        aliases: ["thanksgiving (canada)", "thanksgiving canada"],
+    },
+    // UK Bank Holidays
+    "boxing day": { group: "UK Bank Holidays", calc: (y) => (0, obsidian_1.moment)(new Date(y, 11, 26)) },
 };
 const HOLIDAYS = {};
 const GROUP_HOLIDAYS = {};

--- a/src/main.ts
+++ b/src/main.ts
@@ -80,6 +80,12 @@ function lastWeekdayOfMonth(year: number, month: number, weekday: number) {
         return last.subtract(diff, "day");
 }
 
+function weekdayOnOrBefore(year: number, month: number, day: number, weekday: number) {
+        const target = moment(new Date(year, month, day));
+        const diff = (target.weekday() - weekday + 7) % 7;
+        return target.subtract(diff, "day");
+}
+
 interface HolidayDef {
         group: string;
         calc: (y: number) => moment.Moment;
@@ -138,6 +144,18 @@ const HOLIDAY_DEFS: Record<string, HolidayDef> = {
         "easter": { group: "Christian Holidays", calc: (y) => easter(y), aliases: ["easter sunday"] },
         "good friday": { group: "Christian Holidays", calc: (y) => easter(y).subtract(2, "day") },
         "ash wednesday": { group: "Christian Holidays", calc: (y) => easter(y).subtract(46, "day") },
+
+        // Canadian Federal Holidays
+        "canada day": { group: "Canadian Federal Holidays", calc: (y) => moment(new Date(y, 6, 1)) },
+        "victoria day": { group: "Canadian Federal Holidays", calc: (y) => weekdayOnOrBefore(y, 4, 24, 1) },
+        "canadian thanksgiving": {
+                group: "Canadian Federal Holidays",
+                calc: (y) => nthWeekdayOfMonth(y, 9, 1, 2),
+                aliases: ["thanksgiving (canada)", "thanksgiving canada"],
+        },
+
+        // UK Bank Holidays
+        "boxing day": { group: "UK Bank Holidays", calc: (y) => moment(new Date(y, 11, 26)) },
 };
 
 interface HolidayEntry extends HolidayDef { canonical: string; }

--- a/test/test.js
+++ b/test/test.js
@@ -138,6 +138,10 @@
   assert.strictEqual(fmt(phraseToMoment('christmas of 2025')), '2025-12-25');
   assert.strictEqual(fmt(phraseToMoment("valentine's day")), '2025-02-14');
   assert.strictEqual(fmt(phraseToMoment('easter')), '2025-04-20');
+  assert.strictEqual(fmt(phraseToMoment('victoria day')), '2024-05-20');
+  assert.strictEqual(fmt(phraseToMoment('canada day')), '2024-07-01');
+  assert.strictEqual(fmt(phraseToMoment('canadian thanksgiving')), '2024-10-14');
+  assert.strictEqual(fmt(phraseToMoment('boxing day')), '2024-12-26');
 
   // holiday toggles
   phraseToMoment.holidayGroups = { 'US Federal Holidays': false };


### PR DESCRIPTION
## Summary
- add `weekdayOnOrBefore` helper
- include Canadian and UK holiday groups
- update README to mention new regions
- cover new holidays in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683ea8aa0ed08326a197001a69d187bf