### PR TITLE
Handle code blocks in convertText

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -860,12 +860,54 @@ export default class DynamicDates extends Plugin {
 
         convertText(text: string): string {
                 const phrases = [...this.allPhrases()].sort((a, b) => b.length - a.length);
-                for (const p of phrases) {
-                        const esc = p.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-                        const re = new RegExp(`\\b${esc}\\b`, "gi");
-                        text = text.replace(re, (m) => this.linkForPhrase(m) ?? m);
+
+                const replace = (seg: string) => {
+                        for (const p of phrases) {
+                                const esc = p.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+                                const re = new RegExp(`\\b${esc}\\b`, "gi");
+                                seg = seg.replace(re, (m) => this.linkForPhrase(m) ?? m);
+                        }
+                        return seg;
+                };
+
+                const parts: string[] = [];
+                let i = 0;
+                while (i < text.length) {
+                        if (text.startsWith("```", i)) {
+                                const end = text.indexOf("```", i + 3);
+                                const endIdx = end === -1 ? text.length : end + 3;
+                                parts.push(text.slice(i, endIdx));
+                                i = endIdx;
+                                continue;
+                        }
+                        if (text[i] === "`") {
+                                const end = text.indexOf("`", i + 1);
+                                const endIdx = end === -1 ? text.length : end + 1;
+                                parts.push(text.slice(i, endIdx));
+                                i = endIdx;
+                                continue;
+                        }
+                        if (text.startsWith("[[", i)) {
+                                const end = text.indexOf("]]", i + 2);
+                                const endIdx = end === -1 ? text.length : end + 2;
+                                parts.push(text.slice(i, endIdx));
+                                i = endIdx;
+                                continue;
+                        }
+
+                        let j = i;
+                        while (j < text.length &&
+                                !text.startsWith("```", j) &&
+                                text[j] !== "`" &&
+                                !text.startsWith("[[", j)) {
+                                j++;
+                        }
+                        const seg = text.slice(i, j);
+                        parts.push(replace(seg));
+                        i = j;
                 }
-                return text;
+
+                return parts.join("");
         }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -244,6 +244,18 @@
   const partial = lf.convertText('nottoday tomorrow');
   assert.strictEqual(partial, 'nottoday [[2024-05-09|tomorrow]]');
 
+  const fenced = lf.convertText('before\n```js\ncode tomorrow\n```\nafter tomorrow');
+  assert.strictEqual(fenced,
+    'before\n```js\ncode tomorrow\n```\nafter [[2024-05-09|tomorrow]]');
+
+  const inline = lf.convertText('This `code tomorrow` stays and tomorrow changes');
+  assert.strictEqual(inline,
+    'This `code tomorrow` stays and [[2024-05-09|tomorrow]] changes');
+
+  const linked = lf.convertText('already [[tomorrow]] here, but tomorrow also');
+  assert.strictEqual(linked,
+    'already [[tomorrow]] here, but [[2024-05-09|tomorrow]] also');
+
   /* ------------------------------------------------------------------ */
   /* onTrigger additional guard rails                                   */
   /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## Summary
- ignore fenced and inline code when replacing phrases
- avoid touching existing wikilinks
- add regression tests for convertText skipping code and links

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683ee60f73808326b19b4607cafea92f