### PR TITLE
Handle last/next holiday aliases

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -349,6 +349,12 @@ function needsYearAlias(phrase: string): boolean {
         return /^(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+\d{1,2}(?:st|nd|rd|th)?(?:,)?\s*\d{2,4}$/.test(lower);
 }
 
+function isHolidayQualifier(lower: string): boolean {
+        const m = lower.match(/^(last|next)\s+(.*)$/);
+        if (!m) return false;
+        return m[2] in HOLIDAYS;
+}
+
 const PHRASES = BASE_WORDS.flatMap((w) =>
         WEEKDAYS.includes(w) ? [w, `last ${w}`, `next ${w}`] : [w],
 ).concat(HOLIDAY_PHRASES);
@@ -608,6 +614,12 @@ class DDSuggest extends EditorSuggest<string> {
                                 p.startsWith(phrase) &&
                                 phraseToMoment(p)?.format("YYYY-MM-DD") === target,
                         );
+                if (!candidates.length && isHolidayQualifier(phrase)) {
+                        const m = phraseToMoment(phrase);
+                        if (m && m.format("YYYY-MM-DD") === target) {
+                                candidates.push(phrase);
+                        }
+                }
                 if (candidates.length) {
                         phrase = candidates.sort((a, b) => a.length - b.length)[0];
                 }
@@ -657,6 +669,12 @@ class DDSuggest extends EditorSuggest<string> {
                         p.startsWith(query.toLowerCase()) &&
                         phraseToMoment(p)?.format("YYYY-MM-DD") === targetDate
                 );
+                if (!candidates.length && isHolidayQualifier(query.toLowerCase())) {
+                        const m = phraseToMoment(query.toLowerCase());
+                        if (m && m.format("YYYY-MM-DD") === targetDate) {
+                                candidates.push(query.toLowerCase());
+                        }
+                }
 
 	
                 let phrase = query.toLowerCase();

--- a/test/test.js
+++ b/test/test.js
@@ -12,7 +12,7 @@
   if (!pluginSrc) throw new Error('DynamicDates class not found');
   const settingsSrc = code.match(/const DEFAULT_SETTINGS =[^]*?};/);
   if (!settingsSrc) throw new Error('DEFAULT_SETTINGS not found');
-  const helpersSrc = code.match(/function nthWeekdayOfMonth[^]*?function needsYearAlias[^]*?\n\}/);
+  const helpersSrc = code.match(/function nthWeekdayOfMonth[^]*?function needsYearAlias[^]*?function isHolidayQualifier[^]*?\n\}/);
   if (!helpersSrc) throw new Error('helper functions not found');
   const helpersCode = helpersSrc[0].replace(/const DEFAULT_SETTINGS[^]*?};/, '');
 
@@ -210,6 +210,11 @@
   sugg.context = { editor, start:{line:0,ch:0}, end:{line:0,ch:11}, query:'last may 1' };
   sugg.selectSuggestion('2024-05-01', new KeyboardEvent({ shiftKey:false, key:'Tab' }));
   assert.strictEqual(inserted.pop(), '[[2024-05-01|May 1st, 2024]]');
+
+  // holiday with qualifier should keep phrase
+  sugg.context = { editor, start:{line:0,ch:0}, end:{line:0,ch:14}, query:'last halloween' };
+  sugg.selectSuggestion('2023-10-31', new KeyboardEvent({ shiftKey:false, key:'Tab' }));
+  assert.strictEqual(inserted.pop(), '[[2023-10-31|last Halloween]]');
 
 
   /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## Summary
- add helper `isHolidayQualifier` to detect holiday phrases with qualifiers
- keep typed phrase alias for last/next holiday suggestions
- test holiday qualifier behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683ef34b394c83269a9757d29015b656