### PR TITLE
Fix newline on Shift+Enter

### DIFF
--- a/main.js
+++ b/main.js
@@ -645,6 +645,9 @@ class DDSuggest extends obsidian_1.EditorSuggest {
             if (typeof ev.preventDefault === "function") {
                 ev.preventDefault();
             }
+            if (typeof ev.stopPropagation === "function") {
+                ev.stopPropagation();
+            }
         }
         editor.replaceRange(final, start, end);
         this.close();
@@ -653,6 +656,8 @@ class DDSuggest extends obsidian_1.EditorSuggest {
         if (this.context && ev.key === this.plugin.settings.acceptKey) {
             if (typeof ev.preventDefault === 'function')
                 ev.preventDefault();
+            if (typeof ev.stopPropagation === 'function')
+                ev.stopPropagation();
             const value = this._last[0];
             if (value)
                 this.selectSuggestion(value, ev);
@@ -720,7 +725,7 @@ class DynamicDates extends obsidian_1.Plugin {
         this.registerEditorSuggest(sugg);
         this.registerDomEvent(document, 'keydown', (ev) => {
             sugg.onKeyDown(ev);
-        });
+        }, { capture: true });
         this.addSettingTab(new DDSettingTab(this.app, this));
         this.addCommand({
             id: "convert-dates",

--- a/src/main.ts
+++ b/src/main.ts
@@ -718,6 +718,9 @@ class DDSuggest extends EditorSuggest<string> {
                         if (typeof (ev as any).preventDefault === "function") {
                                 (ev as any).preventDefault();
                         }
+                        if (typeof (ev as any).stopPropagation === "function") {
+                                (ev as any).stopPropagation();
+                        }
                 }
 
                 editor.replaceRange(
@@ -733,6 +736,7 @@ class DDSuggest extends EditorSuggest<string> {
         onKeyDown(ev: KeyboardEvent): boolean {
                 if (this.context && ev.key === this.plugin.settings.acceptKey) {
                         if (typeof ev.preventDefault === 'function') ev.preventDefault();
+                        if (typeof ev.stopPropagation === 'function') ev.stopPropagation();
                         const value = this._last[0];
                         if (value) this.selectSuggestion(value, ev);
                         return true;
@@ -812,7 +816,7 @@ export default class DynamicDates extends Plugin {
                 this.registerEditorSuggest(sugg);
                 this.registerDomEvent(document, 'keydown', (ev: KeyboardEvent) => {
                         sugg.onKeyDown(ev);
-                });
+                }, { capture: true });
                 this.addSettingTab(new DDSettingTab(this.app, this));
                 this.addCommand({
                         id: "convert-dates",

--- a/src/obsidian.d.ts
+++ b/src/obsidian.d.ts
@@ -21,7 +21,7 @@ declare module "obsidian" {
     export class Plugin {
         app: App;
         registerEditorSuggest(s: EditorSuggest<any>): void;
-        registerDomEvent(el: any, type: string, cb: (ev: any) => any): void;
+        registerDomEvent(el: any, type: string, cb: (ev: any) => any, options?: any): void;
         addSettingTab(tab: PluginSettingTab): void;
         addCommand(cmd: any): void;
         loadData(): Promise<any>;


### PR DESCRIPTION
## Summary
- stop propagation when accepting a suggestion
- capture keydown event earlier so the editor doesn't add a newline

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f06f201908326b2081fd31d1d8d0e