### PR TITLE
Fix path for daily note links

### DIFF
--- a/main.js
+++ b/main.js
@@ -628,9 +628,7 @@ class DDSuggest extends obsidian_1.EditorSuggest {
         /* ----------------------------------------------------------------
            2. Build the wikilink with alias
         ----------------------------------------------------------------- */
-        const folder = this.plugin.getDailyFolder();
-        const linkPath = (folder ? folder + "/" : "") + value;
-        const link = `[[${linkPath}|${alias}]]`;
+        const link = `[[${value}|${alias}]]`;
         /* ----------------------------------------------------------------
            3. Insert, respecting the Shift-modifier behaviour
         ----------------------------------------------------------------- */
@@ -772,9 +770,7 @@ class DynamicDates extends obsidian_1.Plugin {
                 .map((w) => (isProperNoun(w) ? properCase(w) : w))
                 .join(" ");
         }
-        const folder = this.getDailyFolder();
-        const linkPath = (folder ? folder + "/" : "") + value;
-        return `[[${linkPath}|${alias}]]`;
+        return `[[${value}|${alias}]]`;
     }
     convertText(text) {
         const phrases = [...this.allPhrases()].sort((a, b) => b.length - a.length);

--- a/src/main.ts
+++ b/src/main.ts
@@ -701,9 +701,7 @@ class DDSuggest extends EditorSuggest<string> {
 		/* ----------------------------------------------------------------
 		   2. Build the wikilink with alias
 		----------------------------------------------------------------- */
-                const folder = this.plugin.getDailyFolder();
-                const linkPath = (folder ? folder + "/" : "") + value;
-                const link = `[[${linkPath}|${alias}]]`;
+                const link = `[[${value}|${alias}]]`;
 	
 		/* ----------------------------------------------------------------
 		   3. Insert, respecting the Shift-modifier behaviour
@@ -861,9 +859,7 @@ export default class DynamicDates extends Plugin {
                                 .map((w) => (isProperNoun(w) ? properCase(w) : w))
                                 .join(" ");
                 }
-                const folder = this.getDailyFolder();
-                const linkPath = (folder ? folder + "/" : "") + value;
-                return `[[${linkPath}|${alias}]]`;
+                return `[[${value}|${alias}]]`;
         }
 
         convertText(text: string): string {

--- a/test/test.js
+++ b/test/test.js
@@ -250,10 +250,10 @@
   const lf = new DynamicDates();
   lf.settings = Object.assign({}, plugin.settings);
   lf.getDailyFolder = () => 'Journal';
-  assert.strictEqual(lf.linkForPhrase('tomorrow'), '[[Journal/2024-05-09|tomorrow]]');
-  assert.strictEqual(lf.linkForPhrase('last may 1'), '[[Journal/2024-05-01|last May 1]]');
-  assert.strictEqual(lf.linkForPhrase('may 1, 2023'), '[[Journal/2023-05-01|May 1, 2023]]');
-  assert.strictEqual(lf.linkForPhrase('may 1st, 23'), '[[Journal/2023-05-01|May 1st, 23]]');
+  assert.strictEqual(lf.linkForPhrase('tomorrow'), '[[2024-05-09|tomorrow]]');
+  assert.strictEqual(lf.linkForPhrase('last may 1'), '[[2024-05-01|last May 1]]');
+  assert.strictEqual(lf.linkForPhrase('may 1, 2023'), '[[2023-05-01|May 1, 2023]]');
+  assert.strictEqual(lf.linkForPhrase('may 1st, 23'), '[[2023-05-01|May 1st, 23]]');
   assert.strictEqual(lf.linkForPhrase('nonsense'), null);
 
   /* ------------------------------------------------------------------ */
@@ -304,7 +304,7 @@
   ev1.preventDefault = () => { called1 = true; };
   tSugg.selectSuggestion('2024-05-09', ev1);
   assert.ok(called1);
-  assert.strictEqual(inserted2.pop(), '[[Daily/2024-05-09|tomorrow]]');
+  assert.strictEqual(inserted2.pop(), '[[2024-05-09|tomorrow]]');
 
   const ev2 = new KeyboardEvent({ key:'Enter', shiftKey:true });
   let called2 = false;


### PR DESCRIPTION
## Summary
- use the daily note filename only when inserting a link
- update tests for simplified link paths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f089133bc8326b68a6a8893f36c59