### PR TITLE
Add option to auto-create missing daily notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Dynamic Dates is an Obsidian plugin that turns natural language phrases such as 
 - Define your own phrases (e.g. `Mid Year`) that map to a specific calendar date.
 - Convert an entire note's text to date links via the `Convert natural-language dates` command.
 - Built-in awareness of holidays across multiple regions, including U.S., Canadian and U.K. observances, with settings to enable or disable entire holiday groups or individual holidays.
+- Optionally create missing daily notes from your Daily Notes template when inserting a link.
 
 ## Building
 


### PR DESCRIPTION
## Summary
- add `createMissingNotes` setting
- support creating new daily notes from the Daily Notes template
- document new feature in README
- test that missing notes are created when enabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f12e7a40083268d19557c3d3e183f