### PR TITLE
Fix daily note template path handling

### DIFF
--- a/main.js
+++ b/main.js
@@ -702,7 +702,9 @@ class DynamicDates extends obsidian_1.Plugin {
     }
     getDailyFolder() {
         const daily = this.getDailySettings();
-        return daily?.folder || "";
+        if (!daily?.folder)
+            return "";
+        return (0, obsidian_1.normalizePath)(daily.folder);
     }
     getDateFormat() {
         const daily = this.getDailySettings();
@@ -784,7 +786,8 @@ class DynamicDates extends obsidian_1.Plugin {
         const daily = this.getDailySettings();
         let data = "";
         if (daily?.template) {
-            const tpl = this.app.vault.getAbstractFileByPath(daily.template);
+            const tplPath = (0, obsidian_1.normalizePath)(daily.template);
+            const tpl = this.app.vault.getAbstractFileByPath(tplPath);
             if (tpl) {
                 data = await this.app.vault.read(tpl);
                 data = this.renderDailyTemplate(data, date);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,15 +1,16 @@
 import {
-	App,
-	Editor,
-	EditorPosition,
-	EditorSuggest,
-	EditorSuggestContext,
-	EditorSuggestTriggerInfo,
-	moment,
-	Plugin,
-	PluginSettingTab,
-	Setting,
-	TFile,
+        App,
+        Editor,
+        EditorPosition,
+        EditorSuggest,
+        EditorSuggestContext,
+        EditorSuggestTriggerInfo,
+        moment,
+        normalizePath,
+        Plugin,
+        PluginSettingTab,
+        Setting,
+        TFile,
 } from "obsidian";
 
 /* ------------------------------------------------------------------ */
@@ -791,7 +792,8 @@ export default class DynamicDates extends Plugin {
 
         getDailyFolder(): string {
                 const daily = this.getDailySettings();
-                return daily?.folder || "";
+                if (!daily?.folder) return "";
+                return normalizePath(daily.folder);
         }
 
         getDateFormat(): string {
@@ -875,7 +877,8 @@ export default class DynamicDates extends Plugin {
                 const daily = this.getDailySettings();
                 let data = "";
                 if (daily?.template) {
-                        const tpl = this.app.vault.getAbstractFileByPath(daily.template);
+                        const tplPath = normalizePath(daily.template);
+                        const tpl = this.app.vault.getAbstractFileByPath(tplPath);
                         if (tpl) {
                                 data = await this.app.vault.read(tpl as TFile);
                                 data = this.renderDailyTemplate(data, date);

--- a/src/obsidian.d.ts
+++ b/src/obsidian.d.ts
@@ -1,5 +1,6 @@
 declare module "obsidian" {
     export const moment: (...args: any[]) => moment.Moment;
+    export function normalizePath(path: string): string;
     export namespace moment { export type Moment = any; }
 
     export interface TAbstractFile { path: string; }

--- a/test/test.js
+++ b/test/test.js
@@ -94,7 +94,15 @@
   const WEEKDAYS = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];
   const BASE_WORDS = ['today','yesterday','tomorrow', ...WEEKDAYS];
 
-  const obsidian_1 = { moment, EditorSuggest, KeyboardEvent, Plugin, PluginSettingTab, Setting };
+  const obsidian_1 = {
+    moment,
+    EditorSuggest,
+    KeyboardEvent,
+    Plugin,
+    PluginSettingTab,
+    Setting,
+    normalizePath: p => p.replace(/\\/g, '/')
+  };
   const context = { moment, WEEKDAYS, MONTHS, BASE_WORDS, EditorSuggest, KeyboardEvent, Plugin, PluginSettingTab, Setting, obsidian_1 };
   vm.createContext(context);
   vm.runInContext('this.MONTH_ABBR = this.MONTHS.map(m => m.slice(0,3));', context);
@@ -400,7 +408,7 @@
   /* ------------------------------------------------------------------ */
   /* createMissingNotes feature                                         */
   /* ------------------------------------------------------------------ */
-  const files = { 'tpl.md': { path:'tpl.md', data:'Date {{date}} {{time}} {{title}} {{date:YYYY}}' } };
+  const files = { 'Templates/tpl.md': { path:'Templates/tpl.md', data:'Date {{date}} {{time}} {{title}} {{date:YYYY}}' } };
   const vlt = {
     files,
     getAbstractFileByPath(p){ return this.files[p] || null; },
@@ -411,7 +419,7 @@
   const cmPlugin = new DynamicDates();
   cmPlugin.app = { vault: vlt, workspace:{} };
   cmPlugin.settings = Object.assign({}, plugin.settings, { createMissingNotes: true });
-  cmPlugin.getDailySettings = () => ({ folder:'Daily', template:'tpl.md', format:'YYYY-MM-DD' });
+  cmPlugin.getDailySettings = () => ({ folder:'Daily', template:'Templates\\tpl.md', format:'YYYY-MM-DD' });
   const cmSugg = new DDSuggest(cmPlugin.app, cmPlugin);
   cmSugg.context = { editor:{ replaceRange:()=>{}, getLine:()=>'' }, start:{line:0,ch:0}, end:{line:0,ch:3}, query:'tom' };
   await cmSugg.selectSuggestion('2024-05-09', new KeyboardEvent({ key:'Tab', shiftKey:false }));


### PR DESCRIPTION
## Summary
- normalize template and folder paths using `normalizePath`
- update test harness to cover Windows-style template paths
- adjust obsidian type stubs for `normalizePath`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683f1b81590c8326b386ba0f8825c4cc