### PR TITLE
Fix daily note template delegation

### DIFF
--- a/main.js
+++ b/main.js
@@ -801,8 +801,18 @@ class DynamicDates extends obsidian_1.Plugin {
         }
         if (createDailyNote) {
             const m = (0, obsidian_1.moment)(date, "YYYY-MM-DD");
-            await createDailyNote(m, this.app);
-            return;
+            try {
+                await createDailyNote(m, this.app);
+            }
+            catch { }
+            if (!this.app.vault.getAbstractFileByPath(path)) {
+                try {
+                    await createDailyNote(this.app, m);
+                }
+                catch { }
+            }
+            if (this.app.vault.getAbstractFileByPath(path))
+                return;
         }
         const daily = this.getDailySettings();
         let data = "";

--- a/src/main.ts
+++ b/src/main.ts
@@ -892,8 +892,15 @@ export default class DynamicDates extends Plugin {
                 }
                 if (createDailyNote) {
                         const m = moment(date, "YYYY-MM-DD");
-                        await createDailyNote(m, this.app);
-                        return;
+                        try {
+                                await createDailyNote(m, this.app);
+                        } catch {}
+                        if (!this.app.vault.getAbstractFileByPath(path)) {
+                                try {
+                                        await createDailyNote(this.app, m);
+                                } catch {}
+                        }
+                        if (this.app.vault.getAbstractFileByPath(path)) return;
                 }
 
                 const daily = this.getDailySettings();

--- a/test/test.js
+++ b/test/test.js
@@ -430,6 +430,37 @@
   );
 
   /* ------------------------------------------------------------------ */
+  /* ensureDailyNote delegates to createDailyNote when available         */
+  /* ------------------------------------------------------------------ */
+  const vlt2 = {
+    files: {},
+    getAbstractFileByPath(p){ return this.files[p] || null; },
+    createFolder(p){ this.files[p] = {}; },
+    read(){ return ''; },
+    create(p,d){ this.files[p] = { path:p, data:d }; }
+  };
+
+  context.require = () => ({ createDailyNote: async (app, m) => {
+    vlt2.create(`Daily/${m.format('YYYY-MM-DD')}.md`, 'FROM TEMPLATE');
+  }});
+
+  const ednPlugin = new DynamicDates();
+  ednPlugin.app = { vault: vlt2, workspace:{} };
+  ednPlugin.getDailySettings = () => ({ folder:'Daily', template:'', format:'YYYY-MM-DD' });
+  await ednPlugin.ensureDailyNote('2024-05-10');
+  assert.ok(vlt2.getAbstractFileByPath('Daily/2024-05-10.md'));
+
+  delete context.require;
+
+  context.require = () => ({ createDailyNote: async (m, app) => {
+    vlt2.create(`Daily/${m.format('YYYY-MM-DD')}.md`, 'REV');
+  }});
+  vlt2.files = {};
+  await ednPlugin.ensureDailyNote('2024-05-11');
+  assert.ok(vlt2.getAbstractFileByPath('Daily/2024-05-11.md'));
+  delete context.require;
+
+  /* ------------------------------------------------------------------ */
   /* helper functions                                                   */
   /* ------------------------------------------------------------------ */
 


### PR DESCRIPTION
## Summary
- ensureDailyNote tries both argument orders for `createDailyNote`
- test createDailyNote delegation via `require` stub

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f20d32d0c8326835abeeff367adc9