### PR TITLE
Fix daily note creation

### DIFF
--- a/main.js
+++ b/main.js
@@ -802,9 +802,15 @@ class DynamicDates extends obsidian_1.Plugin {
         if (createDailyNote) {
             const m = (0, obsidian_1.moment)(date, "YYYY-MM-DD");
             try {
-                await createDailyNote(m, this.app);
+                await createDailyNote(m);
             }
             catch { }
+            if (!this.app.vault.getAbstractFileByPath(path)) {
+                try {
+                    await createDailyNote(m, this.app);
+                }
+                catch { }
+            }
             if (!this.app.vault.getAbstractFileByPath(path)) {
                 try {
                     await createDailyNote(this.app, m);

--- a/src/main.ts
+++ b/src/main.ts
@@ -878,7 +878,7 @@ export default class DynamicDates extends Plugin {
                 // Try to delegate to the Daily Notes plugin if possible so that
                 // the user's configured template (and any integrations like the
                 // Templates core plugin) are correctly applied.
-                let createDailyNote: ((d: moment.Moment, app: any) => Promise<void>) | undefined;
+                let createDailyNote: any;
                 const hasReq = typeof (globalThis as any).require === 'function';
                 if (hasReq) {
                         try {
@@ -893,8 +893,13 @@ export default class DynamicDates extends Plugin {
                 if (createDailyNote) {
                         const m = moment(date, "YYYY-MM-DD");
                         try {
-                                await createDailyNote(m, this.app);
+                                await createDailyNote(m);
                         } catch {}
+                        if (!this.app.vault.getAbstractFileByPath(path)) {
+                                try {
+                                        await createDailyNote(m, this.app);
+                                } catch {}
+                        }
                         if (!this.app.vault.getAbstractFileByPath(path)) {
                                 try {
                                         await createDailyNote(this.app, m);


### PR DESCRIPTION
## Summary
- revise `ensureDailyNote` to mimic Calendar plugin behaviour
- try multiple argument orders when calling `createDailyNote`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f2ee9b75483268be94c4f8b953a19