### PR TITLE
Fix daily note template creation

### DIFF
--- a/main.js
+++ b/main.js
@@ -698,7 +698,8 @@ class DynamicDates extends obsidian_1.Plugin {
             }
             catch { }
         }
-        return this.app.internalPlugins?.plugins?.["daily-notes"]?.instance?.options || {};
+        const dn = this.app.internalPlugins?.plugins?.["daily-notes"];
+        return dn?.instance?.options || dn?.options || {};
     }
     getDailyFolder() {
         const daily = this.getDailySettings();
@@ -802,7 +803,7 @@ class DynamicDates extends obsidian_1.Plugin {
         if (createDailyNote) {
             const m = (0, obsidian_1.moment)(date, this.getDateFormat());
             try {
-                await createDailyNote(m);
+                await createDailyNote(this.app, m);
             }
             catch { }
             if (!this.app.vault.getAbstractFileByPath(path)) {
@@ -813,7 +814,7 @@ class DynamicDates extends obsidian_1.Plugin {
             }
             if (!this.app.vault.getAbstractFileByPath(path)) {
                 try {
-                    await createDailyNote(this.app, m);
+                    await createDailyNote(m);
                 }
                 catch { }
             }

--- a/src/main.ts
+++ b/src/main.ts
@@ -787,7 +787,8 @@ export default class DynamicDates extends Plugin {
                                 return mc.getDailyNoteSettings();
                         } catch {}
                 }
-                return (this.app as any).internalPlugins?.plugins?.["daily-notes"]?.instance?.options || {};
+                const dn = (this.app as any).internalPlugins?.plugins?.["daily-notes"];
+                return dn?.instance?.options || dn?.options || {};
         }
 
         getDailyFolder(): string {
@@ -893,7 +894,7 @@ export default class DynamicDates extends Plugin {
                 if (createDailyNote) {
                         const m = moment(date, this.getDateFormat());
                         try {
-                                await createDailyNote(m);
+                                await createDailyNote(this.app, m);
                         } catch {}
                         if (!this.app.vault.getAbstractFileByPath(path)) {
                                 try {
@@ -902,7 +903,7 @@ export default class DynamicDates extends Plugin {
                         }
                         if (!this.app.vault.getAbstractFileByPath(path)) {
                                 try {
-                                        await createDailyNote(this.app, m);
+                                        await createDailyNote(m);
                                 } catch {}
                         }
                         if (this.app.vault.getAbstractFileByPath(path)) return;


### PR DESCRIPTION
## Summary
- ensure fallback daily note settings work when the core plugin is disabled
- call `createDailyNote` with `app` first to match current API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f32f1fb7483268f7e5d47548d0351