### PR TITLE
Improve suggestion guard logic

### DIFF
--- a/main.js
+++ b/main.js
@@ -474,6 +474,34 @@ class DDSuggest extends obsidian_1.EditorSuggest {
      */
     onTrigger(cursor, editor, _file) {
         const lineBefore = editor.getLine(cursor.line).slice(0, cursor.ch);
+        /* ----------------------------------------------------------
+           Skip suggestions inside code or wiki links
+        ----------------------------------------------------------- */
+        // inside fenced block?
+        let fenced = false;
+        for (let i = 0; i <= cursor.line; i++) {
+            let line = editor.getLine(i);
+            if (i === cursor.line)
+                line = line.slice(0, cursor.ch);
+            let idx = 0;
+            while ((idx = line.indexOf("```", idx)) !== -1) {
+                fenced = !fenced;
+                idx += 3;
+            }
+        }
+        if (fenced)
+            return null;
+        // inside inline code?
+        if ((lineBefore.split("`").length - 1) % 2 === 1)
+            return null;
+        // inside a wiki link?
+        const fullLine = editor.getLine(cursor.line);
+        const open = fullLine.lastIndexOf("[[", cursor.ch);
+        if (open !== -1) {
+            const close = fullLine.indexOf("]]", open + 2);
+            if (close === -1 || close >= cursor.ch)
+                return null;
+        }
         // Track word positions so we can look back multiple words
         const words = [];
         lineBefore.replace(/\S+/g, (w, off) => {

--- a/test/test.js
+++ b/test/test.js
@@ -295,11 +295,37 @@
     'already [[tomorrow]] here, but [[2024-05-09|tomorrow]] also');
 
   /* ------------------------------------------------------------------ */
-  /* onTrigger additional guard rails                                   */
+  /* onTrigger context guards                                           */
   /* ------------------------------------------------------------------ */
   const tPlugin = { settings: Object.assign({}, plugin.settings), dailyFolder:'Daily', allPhrases: () => PHRASES, getDailyFolder(){ return this.dailyFolder; }, getDailySettings(){ return { folder:this.dailyFolder, template:'tpl.md', format:'YYYY-MM-DD' }; }, getDateFormat(){ return this.getDailySettings().format; }, customCanonical(){ return null; } };
   const tApp = { vault:{}, workspace:{} };
   const tSugg = new DDSuggest(tApp, tPlugin);
+
+  // within fenced code block
+  const fenceLines = ['```', 'tom'];
+  assert.strictEqual(tSugg.onTrigger(
+    { line:1, ch:3 },
+    { getLine:(i)=>fenceLines[i] },
+    null
+  ), null);
+
+  // within inline code
+  assert.strictEqual(tSugg.onTrigger(
+    { line:0, ch:11 },
+    { getLine:()=> 'prefix `tom' },
+    null
+  ), null);
+
+  // within wikilink
+  assert.strictEqual(tSugg.onTrigger(
+    { line:0, ch:12 },
+    { getLine:()=> 'prefix [[tom' },
+    null
+  ), null);
+
+  /* ------------------------------------------------------------------ */
+  /* onTrigger additional guard rails                                   */
+  /* ------------------------------------------------------------------ */
   assert.strictEqual(tSugg.onTrigger({line:0,ch:4}, { getLine:()=> 'next' }, null), null);
   assert.ok(tSugg.onTrigger({line:0,ch:11}, { getLine:()=> 'next friday' }, null));
 


### PR DESCRIPTION
## Summary
- avoid triggering suggestions in code fences, inline code, or wikilinks
- test new onTrigger guard logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f4508b11083269fde62945a400a83