### PR TITLE
Implement additional weekday phrase parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Dynamic Dates is an Obsidian plugin that turns natural language phrases such as 
 ## Features
 
 - Suggest dates while typing phrases like **today**, **tomorrow** or **next Monday**.
+- Understand phrases such as **the Tuesday previous** or **the Monday before**,
+  as well as **first Tuesday in July** style expressions.
 - Insert a wiki link to your daily note using <kbd>Tab</kbd> or <kbd>Enter</kbd>.
 - Define your own phrases (e.g. `Mid Year`) that map to a specific calendar date.
 - Convert an entire note's text to date links via the `Convert natural-language dates` command.

--- a/main.js
+++ b/main.js
@@ -420,6 +420,31 @@ function phraseToMoment(phrase) {
             return target;
         }
     }
+    const beforeWd = lower.match(/^the\s+(sunday|monday|tuesday|wednesday|thursday|friday|saturday)\s+(?:before|previous)$/);
+    if (beforeWd)
+        return phraseToMoment(`last ${beforeWd[1]}`);
+    const nthWd = lower.match(/^(?:the\s+)?(first|second|third|fourth|fifth|last)\s+(sunday|monday|tuesday|wednesday|thursday|friday|saturday)\s+(?:in|of)\s+(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)/i);
+    if (nthWd) {
+        const order = nthWd[1];
+        const wd = WEEKDAYS.indexOf(nthWd[2]);
+        const monthName = expandMonthName(nthWd[3]);
+        const monthIdx = MONTHS.indexOf(monthName.toLowerCase());
+        let target;
+        if (order === "last") {
+            target = lastWeekdayOfMonth(now.year(), monthIdx, wd);
+        }
+        else {
+            const map = { first: 1, second: 2, third: 3, fourth: 4, fifth: 5 };
+            target = nthWeekdayOfMonth(now.year(), monthIdx, wd, map[order]);
+        }
+        if (target.isBefore(now, "day")) {
+            if (order === "last")
+                target = lastWeekdayOfMonth(now.year() + 1, monthIdx, wd);
+            else
+                target = nthWeekdayOfMonth(now.year() + 1, monthIdx, wd, { first: 1, second: 2, third: 3, fourth: 4, fifth: 5 }[order]);
+        }
+        return target;
+    }
     const weekdays = WEEKDAYS;
     for (let i = 0; i < 7; i++) {
         const name = weekdays[i];

--- a/src/main.ts
+++ b/src/main.ts
@@ -471,6 +471,29 @@ function phraseToMoment(phrase: string): moment.Moment | null {
                 }
         }
 
+        const beforeWd = lower.match(/^the\s+(sunday|monday|tuesday|wednesday|thursday|friday|saturday)\s+(?:before|previous)$/);
+        if (beforeWd) return phraseToMoment(`last ${beforeWd[1]}`);
+
+        const nthWd = lower.match(/^(?:the\s+)?(first|second|third|fourth|fifth|last)\s+(sunday|monday|tuesday|wednesday|thursday|friday|saturday)\s+(?:in|of)\s+(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)/i);
+        if (nthWd) {
+                const order = nthWd[1];
+                const wd = WEEKDAYS.indexOf(nthWd[2]);
+                const monthName = expandMonthName(nthWd[3]);
+                const monthIdx = MONTHS.indexOf(monthName.toLowerCase());
+                let target: moment.Moment;
+                if (order === "last") {
+                        target = lastWeekdayOfMonth(now.year(), monthIdx, wd);
+                } else {
+                        const map: Record<string, number> = { first:1, second:2, third:3, fourth:4, fifth:5 };
+                        target = nthWeekdayOfMonth(now.year(), monthIdx, wd, map[order]);
+                }
+                if (target.isBefore(now, "day")) {
+                        if (order === "last") target = lastWeekdayOfMonth(now.year()+1, monthIdx, wd);
+                        else target = nthWeekdayOfMonth(now.year()+1, monthIdx, wd, ({ first:1, second:2, third:3, fourth:4, fifth:5 } as any)[order]);
+                }
+                return target;
+        }
+
         const weekdays = WEEKDAYS;
 
         for (let i = 0; i < 7; i++) {

--- a/test/test.js
+++ b/test/test.js
@@ -156,6 +156,11 @@
   assert.strictEqual(fmt(phraseToMoment('jan 1')), '2025-01-01');
   assert.strictEqual(fmt(phraseToMoment('last may 1')), '2024-05-01');
   assert.strictEqual(fmt(phraseToMoment('the 24th')), '2024-05-24');
+  assert.strictEqual(fmt(phraseToMoment('the tuesday previous')), '2024-05-07');
+  assert.strictEqual(fmt(phraseToMoment('the monday before')), '2024-05-06');
+  assert.strictEqual(fmt(phraseToMoment('first tuesday in july')), '2024-07-02');
+  assert.strictEqual(fmt(phraseToMoment('second thursday of june')), '2024-06-13');
+  assert.strictEqual(fmt(phraseToMoment('last friday of november')), '2024-11-29');
   assert.strictEqual(fmt(phraseToMoment('may 1, 2023')), '2023-05-01');
   assert.strictEqual(fmt(phraseToMoment('may 1st, 2023')), '2023-05-01');
   assert.strictEqual(fmt(phraseToMoment('may 1, 23')), '2023-05-01');


### PR DESCRIPTION
## Summary
- extend `phraseToMoment` with support for phrases like "the Tuesday previous"
- add handling for "first/second/etc <weekday> in <month>" constructs
- document new phrases in README
- cover new behaviour with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f47872da483268645bf05e739dcde