### PR TITLE
Preserve user phrasing for nth weekday suggestions

### DIFF
--- a/main.js
+++ b/main.js
@@ -307,6 +307,15 @@ function isHolidayQualifier(lower) {
         return false;
     return m[2] in HOLIDAYS;
 }
+function formatTypedPhrase(phrase) {
+    return phrase
+        .split(/\s+/)
+        .map((w) => w
+        .split("-")
+        .map((p) => (isProperNoun(p) ? properCase(p) : p))
+        .join("-"))
+        .join(" ");
+}
 const PHRASES = BASE_WORDS.flatMap((w) => WEEKDAYS.includes(w) ? [w, `last ${w}`, `next ${w}`] : [w]).concat(HOLIDAY_PHRASES);
 /**
  * Convert a natural-language phrase into a moment date instance.
@@ -624,8 +633,13 @@ class DDSuggest extends obsidian_1.EditorSuggest {
             }
         }
         else {
-            const fmt = needsYearAlias(query) ? "MMMM Do, YYYY" : "MMMM Do";
-            alias = (0, obsidian_1.moment)(target, "YYYY-MM-DD").format(fmt);
+            if (phraseToMoment(query.toLowerCase()) && !needsYearAlias(query)) {
+                alias = formatTypedPhrase(query);
+            }
+            else {
+                const fmt = needsYearAlias(query) ? "MMMM Do, YYYY" : "MMMM Do";
+                alias = (0, obsidian_1.moment)(target, "YYYY-MM-DD").format(fmt);
+            }
         }
         const niceDate = (0, obsidian_1.moment)(target, "YYYY-MM-DD").format("MMMM Do, YYYY");
         el.createDiv({ text: `${niceDate} (${alias})` });
@@ -675,8 +689,13 @@ class DDSuggest extends obsidian_1.EditorSuggest {
             }
         }
         else {
-            const fmt = needsYearAlias(query) ? "MMMM Do, YYYY" : "MMMM Do";
-            alias = (0, obsidian_1.moment)(targetDate, "YYYY-MM-DD").format(fmt);
+            if (phraseToMoment(query.toLowerCase()) && !needsYearAlias(query)) {
+                alias = formatTypedPhrase(query);
+            }
+            else {
+                const fmt = needsYearAlias(query) ? "MMMM Do, YYYY" : "MMMM Do";
+                alias = (0, obsidian_1.moment)(targetDate, "YYYY-MM-DD").format(fmt);
+            }
         }
         /* ----------------------------------------------------------------
            2. Build the wikilink with alias

--- a/test/test.js
+++ b/test/test.js
@@ -12,9 +12,11 @@
   if (!pluginSrc) throw new Error('DynamicDates class not found');
   const settingsSrc = code.match(/const DEFAULT_SETTINGS =[^]*?};/);
   if (!settingsSrc) throw new Error('DEFAULT_SETTINGS not found');
-  const helpersSrc = code.match(/function nthWeekdayOfMonth[^]*?function needsYearAlias[^]*?function isHolidayQualifier[^]*?\n\}/);
+  const helpersSrc = code.match(/function nthWeekdayOfMonth[^]*?function needsYearAlias[^]*?function isHolidayQualifier[^]*?function formatTypedPhrase[^]*?\nconst PHRASES/);
   if (!helpersSrc) throw new Error('helper functions not found');
-  const helpersCode = helpersSrc[0].replace(/const DEFAULT_SETTINGS[^]*?};/, '');
+  const helpersCode = helpersSrc[0]
+    .replace(/const DEFAULT_SETTINGS[^]*?};/, '')
+    .replace(/\nconst PHRASES[^]*/, '');
 
   /* ------------------------------------------------------------------ */
   /* Minimal runtime stubs                                              */
@@ -253,6 +255,15 @@
   sugg.context = { editor, start:{line:0,ch:0}, end:{line:0,ch:14}, query:'last halloween' };
   await sugg.selectSuggestion('2023-10-31', new KeyboardEvent({ shiftKey:false, key:'Tab' }));
   assert.strictEqual(inserted.pop(), '[[2023-10-31|last Halloween]]');
+
+  // nth weekday phrases should keep typed phrasing
+  sugg.context = {
+    editor,
+    start:{line:0,ch:0}, end:{line:0,ch:21},
+    query:'The last Friday in June'
+  };
+  await sugg.selectSuggestion('2024-06-28', new KeyboardEvent({ shiftKey:false, key:'Tab' }));
+  assert.strictEqual(inserted.pop(), '[[2024-06-28|The last Friday in June]]');
 
 
   /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## Summary
- keep user phrasing when selecting nth weekday expressions
- add regression test for this behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f68a3af508326bf02810f5eacf96d