### PR TITLE
Sync manifest version with package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ npm run zip
 
 Upload the generated `dynamic-dates-<version>.zip` file when creating a GitHub release.
 
+When preparing a new release, run one of the standard version commands such as:
+
+```bash
+npm version patch
+```
+
+This will bump `package.json` and automatically update `manifest.json` via the
+`version` script so that both files share the same version number.
+
 ## Continuous Integration
 
 This project uses [GitHub Actions](https://github.com/features/actions) to run

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "tsc && cp dist/main.js main.js",
     "test": "npm run build && node test/test.js",
-    "zip": "npm run build && zip -r dynamic-dates-$npm_package_version.zip main.js manifest.json README.md LICENSE"
+    "zip": "npm run build && zip -r dynamic-dates-$npm_package_version.zip main.js manifest.json README.md LICENSE",
+    "version": "node scripts/updateManifest.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/updateManifest.js
+++ b/scripts/updateManifest.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+const manifestPath = 'manifest.json';
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+
+if (manifest.version !== pkg.version) {
+  manifest.version = pkg.version;
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+  console.log(`Updated manifest.json to version ${pkg.version}`);
+} else {
+  console.log('manifest.json already up to date');
+}
+


### PR DESCRIPTION
## Summary
- keep `manifest.json` version in sync with `package.json`
- run update script via `npm version`
- document the release command in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684027b90f008326af891e9cde6c11a1