### PR TITLE
Cache holiday calculations to avoid repetition

### DIFF
--- a/main.js
+++ b/main.js
@@ -118,6 +118,7 @@ function chineseDateInYear(gYear, cMonth, cDay) {
     }
     return obsidian_1.moment.invalid();
 }
+const HOLIDAY_CACHE = {};
 function easter(y) {
     const a = y % 19;
     const b = Math.floor(y / 100);
@@ -195,6 +196,18 @@ const HOLIDAY_DEFS = {
     // UK Bank Holidays
     "boxing day": { group: "UK Bank Holidays", calc: (y) => (0, obsidian_1.moment)(new Date(y, 11, 26)) },
 };
+for (const [name, def] of Object.entries(HOLIDAY_DEFS)) {
+    const orig = def.calc;
+    def.calc = (y) => {
+        const key = `${y}:${name}`;
+        let m = HOLIDAY_CACHE[key];
+        if (!m) {
+            m = orig(y).clone();
+            HOLIDAY_CACHE[key] = m;
+        }
+        return m.clone();
+    };
+}
 const HOLIDAYS = {};
 const GROUP_HOLIDAYS = {};
 for (const [canon, def] of Object.entries(HOLIDAY_DEFS)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -155,6 +155,8 @@ interface HolidayDef {
         aliases?: string[];
 }
 
+const HOLIDAY_CACHE: Record<string, moment.Moment> = {};
+
 function easter(y: number): moment.Moment {
         const a = y % 19;
         const b = Math.floor(y / 100);
@@ -240,6 +242,19 @@ const HOLIDAY_DEFS: Record<string, HolidayDef> = {
         // UK Bank Holidays
         "boxing day": { group: "UK Bank Holidays", calc: (y) => moment(new Date(y, 11, 26)) },
 };
+
+for (const [name, def] of Object.entries(HOLIDAY_DEFS)) {
+        const orig = def.calc;
+        def.calc = (y: number) => {
+                const key = `${y}:${name}`;
+                let m = HOLIDAY_CACHE[key];
+                if (!m) {
+                        m = orig(y).clone();
+                        HOLIDAY_CACHE[key] = m;
+                }
+                return m.clone();
+        };
+}
 
 interface HolidayEntry extends HolidayDef { canonical: string; }
 


### PR DESCRIPTION
## Summary
- cache holiday calculations once per year keyed by `<year>:<holiday>`
- wrap all holiday `calc` functions so they read from the cache

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68402b371f748326bad8885fd405c8a9