### PR TITLE
Add buildAlias helper and refactor alias generation

### DIFF
--- a/main.js
+++ b/main.js
@@ -612,36 +612,10 @@ class DDSuggest extends obsidian_1.EditorSuggest {
         if (candidates.length) {
             phrase = candidates.sort((a, b) => a.length - b.length)[0];
         }
-        const custom = this.plugin.customCanonical(phrase);
-        let alias;
         if (candidates.length) {
             phrase = candidates.sort((a, b) => a.length - b.length)[0];
-            const canonical = this.plugin.customCanonical(phrase);
-            if (canonical) {
-                alias = canonical;
-            }
-            else {
-                const typedWords = query.split(/\s+/);
-                const phraseWords = phrase.split(/\s+/);
-                alias = phraseWords
-                    .map((w, i) => {
-                    const t = typedWords[i];
-                    if (["last", "next"].includes(w.toLowerCase()) && t)
-                        return t;
-                    return formatWord(w, t);
-                })
-                    .join(" ");
-            }
         }
-        else {
-            if (phraseToMoment(query.toLowerCase()) && !needsYearAlias(query)) {
-                alias = formatTypedPhrase(query);
-            }
-            else {
-                const fmt = needsYearAlias(query) ? "MMMM Do, YYYY" : "MMMM Do";
-                alias = (0, obsidian_1.moment)(target, "YYYY-MM-DD").format(fmt);
-            }
-        }
+        const alias = this.plugin.buildAlias(phrase, query);
         const niceDate = (0, obsidian_1.moment)(target, "YYYY-MM-DD").format("MMMM Do, YYYY");
         el.createDiv({ text: `${niceDate} (${alias})` });
     }
@@ -663,39 +637,10 @@ class DDSuggest extends obsidian_1.EditorSuggest {
             }
         }
         let phrase = query.toLowerCase();
-        let alias;
-        const custom = this.plugin.customCanonical(phrase);
-        if (custom) {
-            alias = custom;
-        }
-        else if (candidates.length) {
+        if (candidates.length) {
             phrase = candidates.sort((a, b) => a.length - b.length)[0];
-            const canonical = this.plugin.customCanonical(phrase);
-            if (canonical) {
-                alias = canonical;
-            }
-            else {
-                const typedWords = query.split(/\s+/);
-                const phraseWords = phrase.split(/\s+/);
-                alias = phraseWords
-                    .map((w, i) => {
-                    const t = typedWords[i];
-                    if (["last", "next"].includes(w.toLowerCase()) && t)
-                        return t;
-                    return formatWord(w, t);
-                })
-                    .join(" ");
-            }
         }
-        else {
-            if (phraseToMoment(query.toLowerCase()) && !needsYearAlias(query)) {
-                alias = formatTypedPhrase(query);
-            }
-            else {
-                const fmt = needsYearAlias(query) ? "MMMM Do, YYYY" : "MMMM Do";
-                alias = (0, obsidian_1.moment)(targetDate, "YYYY-MM-DD").format(fmt);
-            }
-        }
+        const alias = this.plugin.buildAlias(phrase, query);
         // 2. Build the wikilink with alias
         const link = `[[${value}|${alias}]]`;
         // 3. Insert, respecting the Shift-modifier behaviour
@@ -795,6 +740,44 @@ class DynamicDates extends obsidian_1.Plugin {
     customCanonical(lower) {
         return this.customMap[lower.toLowerCase()] || null;
     }
+    /**
+     * Generate the alias text for a wikilink. The `phrase` parameter
+     * should be the canonical phrase that maps to the target date and
+     * `typed` is the raw text typed by the user.  Pass an empty string
+     * for `typed` when no user input should influence casing.
+     */
+    buildAlias(phrase, typed) {
+        const canonical = this.customCanonical(phrase);
+        if (canonical)
+            return canonical;
+        const target = phraseToMoment(phrase);
+        if (!target)
+            return typed;
+        if (typed) {
+            if (typed.toLowerCase() !== phrase) {
+                const typedWords = typed.split(/\s+/);
+                const phraseWords = phrase.split(/\s+/);
+                return phraseWords
+                    .map((w, i) => {
+                    const t = typedWords[i];
+                    if (["last", "next"].includes(w.toLowerCase()) && t)
+                        return t;
+                    return formatWord(w, t);
+                })
+                    .join(" ");
+            }
+            if (phraseToMoment(typed.toLowerCase()) && !needsYearAlias(typed)) {
+                return formatTypedPhrase(typed);
+            }
+            if (phraseToMoment(typed.toLowerCase()) && needsYearAlias(typed)) {
+                return target.format("MMMM Do, YYYY");
+            }
+        }
+        return phrase
+            .split(/\s+/)
+            .map((w) => (isProperNoun(w) ? properCase(w) : w))
+            .join(" ");
+    }
     async onload() {
         await this.loadSettings();
         const sugg = new DDSuggest(this.app, this);
@@ -837,17 +820,7 @@ class DynamicDates extends obsidian_1.Plugin {
         if (!m)
             return null;
         const value = m.format(this.getDateFormat());
-        const custom = this.customCanonical(phrase);
-        let alias;
-        if (custom) {
-            alias = custom;
-        }
-        else {
-            alias = phrase
-                .split(/\s+/)
-                .map((w) => (isProperNoun(w) ? properCase(w) : w))
-                .join(" ");
-        }
+        const alias = this.buildAlias(phrase, "");
         return `[[${value}|${alias}]]`;
     }
     convertText(text) {

--- a/test/test.js
+++ b/test/test.js
@@ -211,7 +211,7 @@
   /* ------------------------------------------------------------------ */
   /* onTrigger guard rails                                             */
   /* ------------------------------------------------------------------ */
-  const plugin = { settings: { dateFormat: 'YYYY-MM-DD', acceptKey:'Tab', noAliasWithShift: true }, dailyFolder:'', allPhrases: () => PHRASES, getDailyFolder(){ return this.dailyFolder; }, getDailySettings(){ return { folder:this.dailyFolder, template:'tpl.md', format:'YYYY-MM-DD' }; }, getDateFormat(){ return this.getDailySettings().format; }, customCanonical(){ return null; } };
+  const plugin = { settings: { dateFormat: 'YYYY-MM-DD', acceptKey:'Tab', noAliasWithShift: true }, dailyFolder:'', allPhrases: () => PHRASES, getDailyFolder(){ return this.dailyFolder; }, getDailySettings(){ return { folder:this.dailyFolder, template:'tpl.md', format:'YYYY-MM-DD' }; }, getDateFormat(){ return this.getDailySettings().format; }, customCanonical(){ return null; }, buildAlias: DynamicDates.prototype.buildAlias };
   const app = { vault: {} };
   const sugg = new DDSuggest(app, plugin);
 
@@ -313,7 +313,7 @@
   /* ------------------------------------------------------------------ */
   /* onTrigger context guards                                           */
   /* ------------------------------------------------------------------ */
-  const tPlugin = { settings: Object.assign({}, plugin.settings), dailyFolder:'Daily', allPhrases: () => PHRASES, getDailyFolder(){ return this.dailyFolder; }, getDailySettings(){ return { folder:this.dailyFolder, template:'tpl.md', format:'YYYY-MM-DD' }; }, getDateFormat(){ return this.getDailySettings().format; }, customCanonical(){ return null; } };
+  const tPlugin = { settings: Object.assign({}, plugin.settings), dailyFolder:'Daily', allPhrases: () => PHRASES, getDailyFolder(){ return this.dailyFolder; }, getDailySettings(){ return { folder:this.dailyFolder, template:'tpl.md', format:'YYYY-MM-DD' }; }, getDateFormat(){ return this.getDailySettings().format; }, customCanonical(){ return null; }, buildAlias: DynamicDates.prototype.buildAlias };
   const tApp = { vault:{}, workspace:{} };
   const tSugg = new DDSuggest(tApp, tPlugin);
 


### PR DESCRIPTION
## Summary
- add `buildAlias` helper on the plugin
- use helper in `renderSuggestion`, `selectSuggestion` and `linkForPhrase`
- update tests for new helper

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68402d66e3bc8326963b77c3e0acbe69