### PR TITLE
Fix holiday prefix matching

### DIFF
--- a/main.js
+++ b/main.js
@@ -318,6 +318,12 @@ function isHolidayQualifier(lower) {
         return false;
     return m[2] in HOLIDAYS;
 }
+function normalizePhrase(text) {
+    return text.toLowerCase().replace(/[\s-]+/g, "");
+}
+function prefixMatch(candidate, query) {
+    return normalizePhrase(candidate).startsWith(normalizePhrase(query));
+}
 function formatTypedPhrase(phrase) {
     return phrase
         .split(/\s+/)
@@ -561,7 +567,7 @@ class DDSuggest extends obsidian_1.EditorSuggest {
             if (!hasQualifier && query.length < 3)
                 continue;
             // must map to a known phrase or a recognised month/day
-            if (!all.some((p) => p.startsWith(query)) && !phraseToMoment(query))
+            if (!all.some((p) => prefixMatch(p, query)) && !phraseToMoment(query))
                 continue;
             return {
                 start: { line: cursor.line, ch: startCh },
@@ -585,7 +591,7 @@ class DDSuggest extends obsidian_1.EditorSuggest {
         }
         const uniq = new Set();
         for (const p of this.plugin.allPhrases()) {
-            if (!p.startsWith(qLower))
+            if (!prefixMatch(p, qLower))
                 continue;
             const dt = phraseToMoment(p);
             if (dt)
@@ -601,7 +607,7 @@ class DDSuggest extends obsidian_1.EditorSuggest {
         const target = (0, obsidian_1.moment)(value, this.plugin.getDateFormat()).format("YYYY-MM-DD");
         const candidates = this.plugin
             .allPhrases()
-            .filter((p) => p.startsWith(phrase) &&
+            .filter((p) => prefixMatch(p, phrase) &&
             phraseToMoment(p)?.format("YYYY-MM-DD") === target);
         if (!candidates.length && isHolidayQualifier(phrase)) {
             const m = phraseToMoment(phrase);
@@ -628,7 +634,7 @@ class DDSuggest extends obsidian_1.EditorSuggest {
         const { settings } = this.plugin;
         // 1. Find the canonical phrase that maps to this calendar date
         const targetDate = (0, obsidian_1.moment)(value, this.plugin.getDateFormat()).format("YYYY-MM-DD");
-        const candidates = this.plugin.allPhrases().filter(p => p.startsWith(query.toLowerCase()) &&
+        const candidates = this.plugin.allPhrases().filter(p => prefixMatch(p, query.toLowerCase()) &&
             phraseToMoment(p)?.format("YYYY-MM-DD") === targetDate);
         if (!candidates.length && isHolidayQualifier(query.toLowerCase())) {
             const m = phraseToMoment(query.toLowerCase());

--- a/src/main.ts
+++ b/src/main.ts
@@ -375,6 +375,14 @@ function isHolidayQualifier(lower: string): boolean {
         return m[2] in HOLIDAYS;
 }
 
+function normalizePhrase(text: string): string {
+        return text.toLowerCase().replace(/[\s-]+/g, "");
+}
+
+function prefixMatch(candidate: string, query: string): boolean {
+        return normalizePhrase(candidate).startsWith(normalizePhrase(query));
+}
+
 function formatTypedPhrase(phrase: string): string {
         return phrase
                 .split(/\s+/)
@@ -641,7 +649,7 @@ class DDSuggest extends EditorSuggest<string> {
                         if (!hasQualifier && query.length < 3) continue;
 
                         // must map to a known phrase or a recognised month/day
-                        if (!all.some((p) => p.startsWith(query)) && !phraseToMoment(query))
+                        if (!all.some((p) => prefixMatch(p, query)) && !phraseToMoment(query))
                                 continue;
 
                         return {
@@ -670,7 +678,7 @@ class DDSuggest extends EditorSuggest<string> {
 
                 const uniq = new Set<string>();
                 for (const p of this.plugin.allPhrases()) {
-                        if (!p.startsWith(qLower)) continue;
+                        if (!prefixMatch(p, qLower)) continue;
                         const dt = phraseToMoment(p);
                         if (dt) uniq.add(dt.format(this.plugin.getDateFormat()));
                 }
@@ -686,7 +694,7 @@ class DDSuggest extends EditorSuggest<string> {
                 const candidates = this.plugin
                         .allPhrases()
                         .filter((p) =>
-                                p.startsWith(phrase) &&
+                                prefixMatch(p, phrase) &&
                                 phraseToMoment(p)?.format("YYYY-MM-DD") === target,
                         );
                 if (!candidates.length && isHolidayQualifier(phrase)) {
@@ -720,7 +728,7 @@ class DDSuggest extends EditorSuggest<string> {
                 const targetDate = moment(value, this.plugin.getDateFormat()).format("YYYY-MM-DD");
 
                 const candidates = this.plugin.allPhrases().filter(p =>
-                        p.startsWith(query.toLowerCase()) &&
+                        prefixMatch(p, query.toLowerCase()) &&
                         phraseToMoment(p)?.format("YYYY-MM-DD") === targetDate
                 );
                 if (!candidates.length && isHolidayQualifier(query.toLowerCase())) {

--- a/test/test.js
+++ b/test/test.js
@@ -436,6 +436,15 @@
   );
   assert.ok(trig && trig.start.ch === 0);
 
+  const trigPart = s2.onTrigger(
+    { line:0, ch:20 },
+    { getLine:()=> 'start of the new sem' },
+    null
+  );
+  assert.ok(trigPart && trigPart.query === 'start of the new sem');
+  const listPart = s2.getSuggestions({ query: trigPart.query });
+  assert.ok(listPart.includes('2024-08-22'));
+
   const hPlugin = new DynamicDates();
   hPlugin.settings = Object.assign({}, plugin.settings, {
     holidayGroups: { 'US Federal Holidays': true },
@@ -457,6 +466,15 @@
   assert.ok(hCtx && hCtx.query === 'last thanks');
   const hList = hSuggest.getSuggestions({ query: hCtx.query });
   assert.ok(hList.includes('2023-11-23'));
+
+  const hCtx2 = hSuggest.onTrigger(
+    { line:0, ch:10 },
+    { getLine:()=> 'last thank' },
+    null
+  );
+  assert.ok(hCtx2 && hCtx2.query === 'last thank');
+  const hList2 = hSuggest.getSuggestions({ query: hCtx2.query });
+  assert.ok(hList2.includes('2023-11-23'));
 
 
   /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## Summary
- handle prefix matching when words end mid-word
- use new helper prefixMatch across suggestion logic
- test partial holiday/custom phrase detection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6840595ec04083269658777e94e83e2a