### PR TITLE
Handle weekday abbreviations in dynamic date parsing

### DIFF
--- a/docs/wiki-use-cases-and-tests.md
+++ b/docs/wiki-use-cases-and-tests.md
@@ -6,8 +6,8 @@ This page describes the main scenarios the Dynamic Dates Obsidian plugin solves 
 
 1. **Automatic Date Suggestions**  
    Typing natural language phrases such as `today`, `tomorrow` or `next Monday` should trigger a suggestion for the matching calendar date. Accepting the suggestion inserts a wiki link pointing to the daily note.
-2. **Relative Date Phrases**  
-   Expressions like `last Friday`, `the Tuesday previous` or `the Monday before` are recognized and linked appropriately.
+2. **Relative Date Phrases**
+   Expressions like `last Friday`, `the Tuesday previous` or `the Monday before` are recognized and linked appropriately. Weekday names may be abbreviated (e.g. `Tue`).
 3. **Nth Weekday Parsing**  
    Phrases including `first Tuesday in July`, `second Thursday of June` or `last Friday of November` resolve to the corresponding dates.
 4. **Day-of-Month References**  

--- a/main.js
+++ b/main.js
@@ -57,6 +57,22 @@ function weekdayOnOrBefore(year, month, day, weekday) {
     const diff = (target.weekday() - weekday + 7) % 7;
     return target.subtract(diff, "day");
 }
+const WEEKDAY_ALIAS = {
+    sun: "sunday",
+    mon: "monday",
+    tue: "tuesday",
+    tues: "tuesday",
+    wed: "wednesday",
+    weds: "wednesday",
+    thu: "thursday",
+    thur: "thursday",
+    thurs: "thursday",
+    fri: "friday",
+    sat: "saturday",
+};
+function normalizeWeekdayAliases(str) {
+    return str.replace(/\b(?:sun|mon|tues?|wed(?:s)?|thu(?:rs)?|thur|fri|sat)\b/g, (m) => WEEKDAY_ALIAS[m] || m);
+}
 function islamicDateInYear(gYear, iMonth, iDay) {
     const fmt = new Intl.DateTimeFormat("en-u-ca-islamic", {
         day: "numeric",
@@ -336,7 +352,7 @@ function formatTypedPhrase(phrase) {
 const PHRASES = BASE_WORDS.flatMap((w) => WEEKDAYS.includes(w) ? [w, `last ${w}`, `next ${w}`] : [w]).concat(HOLIDAY_PHRASES);
 function phraseToMoment(phrase) {
     const now = (0, obsidian_1.moment)();
-    const lower = phrase.toLowerCase().trim();
+    const lower = normalizeWeekdayAliases(phrase.toLowerCase().trim());
     const customMap = phraseToMoment.customDates || {};
     if (lower in customMap) {
         const val = customMap[lower];

--- a/src/main.ts
+++ b/src/main.ts
@@ -91,6 +91,24 @@ function weekdayOnOrBefore(year: number, month: number, day: number, weekday: nu
         return target.subtract(diff, "day");
 }
 
+const WEEKDAY_ALIAS: Record<string, string> = {
+        sun: "sunday",
+        mon: "monday",
+        tue: "tuesday",
+        tues: "tuesday",
+        wed: "wednesday",
+        weds: "wednesday",
+        thu: "thursday",
+        thur: "thursday",
+        thurs: "thursday",
+        fri: "friday",
+        sat: "saturday",
+};
+
+function normalizeWeekdayAliases(str: string): string {
+        return str.replace(/\b(?:sun|mon|tues?|wed(?:s)?|thu(?:rs)?|thur|fri|sat)\b/g, (m) => WEEKDAY_ALIAS[m] || m);
+}
+
 function islamicDateInYear(gYear: number, iMonth: number, iDay: number): moment.Moment {
         const fmt = new Intl.DateTimeFormat("en-u-ca-islamic", {
                 day: "numeric",
@@ -417,7 +435,7 @@ type PhraseToMomentFunc = {
 
 function phraseToMoment(phrase: string): moment.Moment | null {
         const now = moment();
-        const lower = phrase.toLowerCase().trim();
+        const lower = normalizeWeekdayAliases(phrase.toLowerCase().trim());
 
         const customMap: Record<string,string> = (phraseToMoment as PhraseToMomentFunc).customDates || {};
         if (lower in customMap) {


### PR DESCRIPTION
## Summary
- handle weekday abbreviations such as `Tue` or `Wed`
- document that short weekday names work

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68406209f0d08326aa57c285edc5dab6