### PR TITLE
Fix duplicate candidate sorting in suggestion

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -721,14 +721,9 @@ class DDSuggest extends EditorSuggest<string> {
                                 candidates.push(phrase);
                         }
                 }
-                if (candidates.length) {
-                        phrase = candidates.sort((a, b) => a.length - b.length)[0];
-                }
-
-
-                if (candidates.length) {
-                        phrase = candidates.sort((a, b) => a.length - b.length)[0];
-                }
+               if (candidates.length) {
+                       phrase = candidates.sort((a, b) => a.length - b.length)[0];
+               }
 
                 const alias = this.plugin.buildAlias(phrase, query);
                 const niceDate = moment(target, "YYYY-MM-DD").format("MMMM Do, YYYY");


### PR DESCRIPTION
## Summary
- remove redundant candidate sort in `renderSuggestion`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6840664a8010832693fbcc9278f74eec