### PR TITLE
Fix year parsing in nth weekday phrases

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -404,6 +404,9 @@ function needsYearAlias(phrase: string): boolean {
         if (/^(?:last|next)\s+(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+\d{1,2}(?:st|nd|rd|th)?$/.test(lower)) {
                 return true;
         }
+        if (/^(?:the\s+)?(first|second|third|fourth|fifth|last)\s+(sunday|monday|tuesday|wednesday|thursday|friday|saturday)\s+(?:in|of)\s+(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+\d{2,4}$/.test(lower)) {
+                return true;
+        }
         return /^(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+\d{1,2}(?:st|nd|rd|th)?(?:,)?\s*\d{2,4}$/.test(lower);
 }
 
@@ -561,20 +564,23 @@ function phraseToMoment(phrase: string): moment.Moment | null {
         const beforeWd = lower.match(/^the\s+(sunday|monday|tuesday|wednesday|thursday|friday|saturday)\s+(?:before|previous)$/);
         if (beforeWd) return phraseToMoment(`last ${beforeWd[1]}`);
 
-        const nthWd = lower.match(/^(?:the\s+)?(first|second|third|fourth|fifth|last)\s+(sunday|monday|tuesday|wednesday|thursday|friday|saturday)\s+(?:in|of)\s+(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)/i);
+        const nthWd = lower.match(/^(?:the\s+)?(first|second|third|fourth|fifth|last)\s+(sunday|monday|tuesday|wednesday|thursday|friday|saturday)\s+(?:in|of)\s+(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)(?:\s+(\d{2,4}))?/i);
         if (nthWd) {
                 const order = nthWd[1];
                 const wd = WEEKDAYS.indexOf(nthWd[2]);
                 const monthName = expandMonthName(nthWd[3]);
+                const yearText = nthWd[4];
                 const monthIdx = MONTHS.indexOf(monthName.toLowerCase());
                 let target: moment.Moment;
                 if (order === "last") {
-                        target = lastWeekdayOfMonth(now.year(), monthIdx, wd);
+                        const yearNum = yearText ? (parseInt(yearText) < 100 ? parseInt(yearText) + 2000 : parseInt(yearText)) : now.year();
+                        target = lastWeekdayOfMonth(yearNum, monthIdx, wd);
                 } else {
                         const map: Record<string, number> = { first:1, second:2, third:3, fourth:4, fifth:5 };
-                        target = nthWeekdayOfMonth(now.year(), monthIdx, wd, map[order]);
+                        const yearNum = yearText ? (parseInt(yearText) < 100 ? parseInt(yearText) + 2000 : parseInt(yearText)) : now.year();
+                        target = nthWeekdayOfMonth(yearNum, monthIdx, wd, map[order]);
                 }
-                if (target.isBefore(now, "day")) {
+                if (!yearText && target.isBefore(now, "day")) {
                         if (order === "last") target = lastWeekdayOfMonth(now.year()+1, monthIdx, wd);
                         else target = nthWeekdayOfMonth(now.year()+1, monthIdx, wd, ({ first:1, second:2, third:3, fourth:4, fifth:5 } as any)[order]);
                 }

--- a/test/test.js
+++ b/test/test.js
@@ -163,6 +163,7 @@
   assert.strictEqual(fmt(phraseToMoment('first tuesday in july')), '2024-07-02');
   assert.strictEqual(fmt(phraseToMoment('second thursday of june')), '2024-06-13');
   assert.strictEqual(fmt(phraseToMoment('last friday of november')), '2024-11-29');
+  assert.strictEqual(fmt(phraseToMoment('last wednesday of august 26')), '2026-08-26');
   assert.strictEqual(fmt(phraseToMoment('may 1, 2023')), '2023-05-01');
   assert.strictEqual(fmt(phraseToMoment('may 1st, 2023')), '2023-05-01');
   assert.strictEqual(fmt(phraseToMoment('may 1, 23')), '2023-05-01');


### PR DESCRIPTION
## Summary
- support specifying a year after nth weekday phrases like `last wednesday of August 26`
- mark such phrases as requiring a year alias
- add unit test for the new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6840ae8f2f108326a6df8f81cbbe3d9b