### PR TITLE
Refactor fenced block detection in onTrigger

### DIFF
--- a/main.js
+++ b/main.js
@@ -569,7 +569,9 @@ class DDSuggest extends obsidian_1.EditorSuggest {
         // Skip suggestions inside code or wiki links
         // inside fenced block?
         let fenced = false;
-        for (let i = 0; i <= cursor.line; i++) {
+        const WINDOW = 20;
+        const startLine = Math.max(0, cursor.line - WINDOW);
+        for (let i = startLine; i <= cursor.line; i++) {
             let line = editor.getLine(i);
             if (i === cursor.line)
                 line = line.slice(0, cursor.ch);

--- a/src/main.ts
+++ b/src/main.ts
@@ -650,19 +650,21 @@ class DDSuggest extends EditorSuggest<string> {
         ): EditorSuggestTriggerInfo | null {
                 const lineBefore = editor.getLine(cursor.line).slice(0, cursor.ch);
 
-                // Skip suggestions inside code or wiki links
-                // inside fenced block?
-                let fenced = false;
-                for (let i = 0; i <= cursor.line; i++) {
-                        let line = editor.getLine(i);
-                        if (i === cursor.line) line = line.slice(0, cursor.ch);
-                        let idx = 0;
-                        while ((idx = line.indexOf("```", idx)) !== -1) {
-                                fenced = !fenced;
-                                idx += 3;
-                        }
-                }
-                if (fenced) return null;
+               // Skip suggestions inside code or wiki links
+               // inside fenced block?
+               let fenced = false;
+               const WINDOW = 20;
+               const startLine = Math.max(0, cursor.line - WINDOW);
+               for (let i = startLine; i <= cursor.line; i++) {
+                       let line = editor.getLine(i);
+                       if (i === cursor.line) line = line.slice(0, cursor.ch);
+                       let idx = 0;
+                       while ((idx = line.indexOf("```", idx)) !== -1) {
+                               fenced = !fenced;
+                               idx += 3;
+                       }
+               }
+               if (fenced) return null;
 
                 // inside inline code?
                 if ((lineBefore.split("`").length - 1) % 2 === 1) return null;


### PR DESCRIPTION
## Summary
- limit fenced code detection to a small lookback window in `onTrigger`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6840b2a92d2c832685d0800aed7a3166