### PR TITLE
Fix nearest date search for nth weekday phrases

### DIFF
--- a/main.js
+++ b/main.js
@@ -496,21 +496,27 @@ function phraseToMoment(phrase) {
         const monthName = expandMonthName(nthWd[3]);
         const yearText = nthWd[4];
         const monthIdx = MONTHS.indexOf(monthName.toLowerCase());
-        let target;
-        if (order === "last") {
-            const yearNum = yearText ? (parseInt(yearText) < 100 ? parseInt(yearText) + 2000 : parseInt(yearText)) : now.year();
-            target = lastWeekdayOfMonth(yearNum, monthIdx, wd);
-        }
-        else {
-            const map = { first: 1, second: 2, third: 3, fourth: 4, fifth: 5 };
-            const yearNum = yearText ? (parseInt(yearText) < 100 ? parseInt(yearText) + 2000 : parseInt(yearText)) : now.year();
-            target = nthWeekdayOfMonth(yearNum, monthIdx, wd, map[order]);
-        }
-        if (!yearText && target.isBefore(now, "day")) {
-            if (order === "last")
-                target = lastWeekdayOfMonth(now.year() + 1, monthIdx, wd);
-            else
-                target = nthWeekdayOfMonth(now.year() + 1, monthIdx, wd, { first: 1, second: 2, third: 3, fourth: 4, fifth: 5 }[order]);
+        const map = { first: 1, second: 2, third: 3, fourth: 4, fifth: 5 };
+        const parseYear = (y) => (parseInt(y) < 100 ? parseInt(y) + 2000 : parseInt(y));
+        const baseYear = yearText ? parseYear(yearText) : now.year();
+        const compute = (y) => order === "last"
+            ? lastWeekdayOfMonth(y, monthIdx, wd)
+            : nthWeekdayOfMonth(y, monthIdx, wd, map[order]);
+        let target = compute(baseYear);
+        if (!yearText) {
+            const prev = compute(baseYear - 1);
+            const next = compute(baseYear + 1);
+            const opts = [target, next, prev];
+            let best = opts[0];
+            let bestDiff = dayDiff(best, now);
+            for (const o of opts.slice(1)) {
+                const diff = dayDiff(o, now);
+                if (diff < bestDiff) {
+                    best = o;
+                    bestDiff = diff;
+                }
+            }
+            target = best;
         }
         return target;
     }

--- a/test/test.js
+++ b/test/test.js
@@ -162,8 +162,11 @@
   assert.strictEqual(fmt(phraseToMoment('the monday before')), '2024-05-06');
   assert.strictEqual(fmt(phraseToMoment('first tuesday in july')), '2024-07-02');
   assert.strictEqual(fmt(phraseToMoment('second thursday of june')), '2024-06-13');
-  assert.strictEqual(fmt(phraseToMoment('last friday of november')), '2024-11-29');
+  assert.strictEqual(fmt(phraseToMoment('last friday of november')), '2023-11-24');
   assert.strictEqual(fmt(phraseToMoment('last wednesday of august 26')), '2026-08-26');
+  moment.now = new Date('2025-06-05');
+  assert.strictEqual(fmt(phraseToMoment('last thursday of may')), '2025-05-29');
+  moment.now = new Date('2024-05-08');
   assert.strictEqual(fmt(phraseToMoment('may 1, 2023')), '2023-05-01');
   assert.strictEqual(fmt(phraseToMoment('may 1st, 2023')), '2023-05-01');
   assert.strictEqual(fmt(phraseToMoment('may 1, 23')), '2023-05-01');


### PR DESCRIPTION
## Summary
- correct `phraseToMoment` so nth weekday phrases pick the closest year
- update compiled `main.js`
- update tests for new behaviour and add regression test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68414c3e13988326a61e6733547a8885