### PR TITLE
Improve alias formatting for month abbreviations

### DIFF
--- a/main.js
+++ b/main.js
@@ -364,12 +364,23 @@ function normalizePhrase(text) {
 function prefixMatch(candidate, query) {
     return normalizePhrase(candidate).startsWith(normalizePhrase(query));
 }
+const MONTH_ABBR_DOT = [
+    "jan", "feb", "mar", "apr", "aug", "sep", "oct", "nov", "dec",
+];
 function formatTypedPhrase(phrase) {
     return phrase
         .split(/\s+/)
         .map((w) => w
         .split("-")
-        .map((p) => (isProperNoun(p) ? properCase(p) : p))
+        .map((p) => {
+        const stripped = p.replace(/\./g, "").toLowerCase();
+        if (MONTH_ABBR.includes(stripped)) {
+            const base = properCase(stripped);
+            const dot = MONTH_ABBR_DOT.includes(stripped) ? "." : (p.includes(".") ? "." : "");
+            return base + dot;
+        }
+        return isProperNoun(p) ? properCase(p) : p;
+    })
         .join("-"))
         .join(" ");
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -424,13 +424,25 @@ function prefixMatch(candidate: string, query: string): boolean {
         return normalizePhrase(candidate).startsWith(normalizePhrase(query));
 }
 
+const MONTH_ABBR_DOT = [
+        "jan", "feb", "mar", "apr", "aug", "sep", "oct", "nov", "dec",
+];
+
 function formatTypedPhrase(phrase: string): string {
         return phrase
                 .split(/\s+/)
                 .map((w) =>
                         w
                                 .split("-")
-                                .map((p) => (isProperNoun(p) ? properCase(p) : p))
+                                .map((p) => {
+                                        const stripped = p.replace(/\./g, "").toLowerCase();
+                                        if (MONTH_ABBR.includes(stripped)) {
+                                                const base = properCase(stripped);
+                                                const dot = MONTH_ABBR_DOT.includes(stripped) ? "." : (p.includes(".") ? "." : "");
+                                                return base + dot;
+                                        }
+                                        return isProperNoun(p) ? properCase(p) : p;
+                                })
                                 .join("-")
                 )
                 .join(" ");

--- a/test/test.js
+++ b/test/test.js
@@ -269,6 +269,11 @@
   await sugg.selectSuggestion('2024-06-28', new KeyboardEvent({ shiftKey:false, key:'Tab' }));
   assert.strictEqual(inserted.pop(), '[[2024-06-28|The last Friday in June]]');
 
+  // abbreviated month names should be capitalized with a period
+  sugg.context = { editor, start:{line:0,ch:0}, end:{line:0,ch:8}, query:'dec 26th' };
+  await sugg.selectSuggestion('2023-12-26', new KeyboardEvent({ shiftKey:false, key:'Tab' }));
+  assert.strictEqual(inserted.pop(), '[[2023-12-26|Dec. 26th]]');
+
 
   /* ------------------------------------------------------------------ */
   /* convertText utility                                               */


### PR DESCRIPTION
## Summary
- support month abbreviations like `Dec` with periods when formatting typed phrases
- add test for abbreviated month alias display

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_684154a252308326b6a5fcf0cff2c6fa