### PR TITLE
Fix missing plugin build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 dist/
 node_modules/
 *.zip
+plugin.js
+holidays.js
+suggest.js

--- a/README.md
+++ b/README.md
@@ -28,12 +28,13 @@ npm run build
 
 ## Packaging for the community plugin store
 
-Run the following command to create a release zip containing `main.js` and `manifest.json`:
+Run the following command to build the plugin and package all runtime files into a release zip:
 
 ```bash
 npm run zip
 ```
 
+This zip includes `main.js`, `plugin.js`, `holidays.js`, `suggest.js` and `manifest.json` so Obsidian can load the plugin without additional build steps.
 Upload the generated `dynamic-dates-<version>.zip` file when creating a GitHub release.
 
 When preparing a new release, run one of the standard version commands such as:

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Obsidian plugin for natural language dates",
   "main": "main.js",
   "scripts": {
-    "build": "tsc && cp dist/main.js main.js",
+    "build": "tsc && cp dist/*.js ./",
     "test": "npm run build && node test/test.js",
-    "zip": "npm run build && zip -r dynamic-dates-$npm_package_version.zip main.js manifest.json README.md LICENSE",
+    "zip": "npm run build && zip -r dynamic-dates-$npm_package_version.zip main.js plugin.js holidays.js suggest.js manifest.json README.md LICENSE",
     "version": "node scripts/updateManifest.js"
   },
   "repository": {


### PR DESCRIPTION
## Summary
- ensure compiled JavaScript files are copied to the plugin root during build
- package all runtime files in the release zip
- keep generated files out of version control
- document the new packaging process

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68417450ad00832682551af1f0f7e09d