### PR TITLE
Restore main.js entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Then run the build command:
 npm run build
 ```
 
-This compiles the TypeScript source and copies the generated `plugin.js`,
-`holidays.js` and `suggest.js` files to the project root.
+This compiles the TypeScript source and copies the generated `main.js`,
+`plugin.js`, `holidays.js` and `suggest.js` files to the project root.
 
 ## Packaging for the community plugin store
 
@@ -37,7 +37,7 @@ Run the following command to create a release zip containing the compiled JavaSc
 npm run zip
 ```
 
-This will produce `dynamic-dates-<version>.zip` containing `plugin.js`,
+This will produce `dynamic-dates-<version>.zip` containing `main.js`, `plugin.js`,
 `holidays.js`, `suggest.js`, `manifest.json`, `README.md` and `LICENSE`. Upload
 this file when creating a GitHub release.
 

--- a/main.js
+++ b/main.js
@@ -1,0 +1,8 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = void 0;
+var plugin_1 = require("./plugin");
+Object.defineProperty(exports, "default", { enumerable: true, get: function () { return __importDefault(plugin_1).default; } });

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "dynamic-dates",
   "name": "Dynamic Dates",
   "version": "1.0.0",
-  "main": "plugin.js",
+  "main": "main.js",
   "minAppVersion": "1.5.0",
   "description": "Suggests natural-language dates and links them to your daily notes, with options for custom phrases.",
   "author": "Matthew Gromer",

--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "dynamic-dates",
   "version": "1.0.0",
   "description": "Obsidian plugin for natural language dates",
-  "main": "plugin.js",
+  "main": "main.js",
   "scripts": {
-    "build": "tsc && cp dist/plugin.js dist/holidays.js dist/suggest.js ./",
+    "build": "tsc && cp dist/*.js ./",
     "test": "npm run build && node test/test.js",
-    "zip": "npm run build && zip -r dynamic-dates-$npm_package_version.zip plugin.js holidays.js suggest.js manifest.json README.md LICENSE",
+    "zip": "npm run build && zip -r dynamic-dates-$npm_package_version.zip main.js plugin.js holidays.js suggest.js manifest.json README.md LICENSE",
     "version": "node scripts/updateManifest.js"
   },
   "repository": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,1 @@
+export { default } from "./plugin";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,5 @@
     "skipLibCheck": true,
     "outDir": "dist"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["src/main.ts"]
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- reintroduce `main.js` to comply with plugin loader expectations
- point manifest and `package.json` back to `main.js`
- copy all compiled JS files in build script
- update README build/package docs

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68417c5535f4832698d85bee7837c45f