### PR TITLE
Move holiday options to a modal

### DIFF
--- a/src/obsidian.d.ts
+++ b/src/obsidian.d.ts
@@ -69,8 +69,18 @@ declare module "obsidian" {
 
     export class PluginSettingTab {
         constructor(app: App, plugin: Plugin);
+        app: App;
+        plugin: Plugin;
         containerEl: HTMLElement;
         display(): void;
+    }
+
+    export class Modal {
+        constructor(app: App);
+        containerEl: HTMLElement;
+        contentEl: HTMLElement;
+        open(): void;
+        close(): void;
     }
 
     export class Setting {


### PR DESCRIPTION
## Summary
- expose Modal type in obsidian.d.ts
- factor out holiday settings renderer
- add `HolidaySettingsModal` and button in settings tab

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684187931c3c8326af421c5c5c2a29e8