### PR TITLE
Remove duplicated weekday constants

### DIFF
--- a/holidays.js
+++ b/holidays.js
@@ -24,18 +24,6 @@ exports.prefixMatch = prefixMatch;
 exports.formatTypedPhrase = formatTypedPhrase;
 exports.phraseToMoment = phraseToMoment;
 const obsidian_1 = require("obsidian");
-exports.BASE_WORDS = [
-    "today",
-    "yesterday",
-    "tomorrow",
-    "monday",
-    "tuesday",
-    "wednesday",
-    "thursday",
-    "friday",
-    "saturday",
-    "sunday",
-];
 exports.WEEKDAYS = [
     "sunday",
     "monday",
@@ -44,6 +32,12 @@ exports.WEEKDAYS = [
     "thursday",
     "friday",
     "saturday",
+];
+exports.BASE_WORDS = [
+    "today",
+    "yesterday",
+    "tomorrow",
+    ...exports.WEEKDAYS,
 ];
 exports.MONTHS = [
     "january",

--- a/main.js
+++ b/main.js
@@ -1,19 +1,9 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const obsidian_1 = require("obsidian");
+// Settings
+const settings_1 = require("./settings");
 // Phrase helpers
-const BASE_WORDS = [
-    "today",
-    "yesterday",
-    "tomorrow",
-    "monday",
-    "tuesday",
-    "wednesday",
-    "thursday",
-    "friday",
-    "saturday",
-    "sunday",
-];
 const WEEKDAYS = [
     "sunday",
     "monday",
@@ -22,6 +12,12 @@ const WEEKDAYS = [
     "thursday",
     "friday",
     "saturday",
+];
+const BASE_WORDS = [
+    "today",
+    "yesterday",
+    "tomorrow",
+    ...WEEKDAYS,
 ];
 const MONTHS = [
     "january",
@@ -286,13 +282,6 @@ function holidayEnabled(name) {
         return groups[g];
     return true;
 }
-const DEFAULT_SETTINGS = {
-    acceptKey: "Tab",
-    noAliasWithShift: false,
-    customDates: {},
-    holidayGroups: Object.fromEntries(Object.keys(GROUP_HOLIDAYS).map(g => [g, false])),
-    holidayOverrides: {},
-};
 function isProperNoun(word) {
     const w = word.toLowerCase();
     if (NON_PROPER_WORDS.has(w))
@@ -764,7 +753,7 @@ class DDSuggest extends obsidian_1.EditorSuggest {
  */
 class DynamicDates extends obsidian_1.Plugin {
     static makeNode() { return { children: new Map(), phrase: null }; }
-    settings = DEFAULT_SETTINGS;
+    settings = settings_1.DEFAULT_SETTINGS;
     customMap = {};
     /** Combined regex built from all phrases */
     combinedRegex = null;
@@ -957,11 +946,12 @@ class DynamicDates extends obsidian_1.Plugin {
         console.log("Dynamic Dates unloaded");
     }
     async loadSettings() {
-        this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+        this.settings = Object.assign({}, settings_1.DEFAULT_SETTINGS, await this.loadData());
         if (!this.settings.customDates)
             this.settings.customDates = {};
-        if (!this.settings.holidayGroups)
+        if (!this.settings.holidayGroups || Object.keys(this.settings.holidayGroups).length === 0) {
             this.settings.holidayGroups = Object.fromEntries(Object.keys(GROUP_HOLIDAYS).map(g => [g, false]));
+        }
         if (!this.settings.holidayOverrides)
             this.settings.holidayOverrides = {};
         this.refreshCustomMap();

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,19 +21,6 @@ import { DDSettings, DEFAULT_SETTINGS } from "./settings";
 
 // Phrase helpers
 
-const BASE_WORDS = [
-        "today",
-        "yesterday",
-        "tomorrow",
-        "monday",
-        "tuesday",
-        "wednesday",
-        "thursday",
-        "friday",
-        "saturday",
-        "sunday",
-];
-
 const WEEKDAYS = [
         "sunday",
         "monday",
@@ -42,6 +29,13 @@ const WEEKDAYS = [
         "thursday",
         "friday",
         "saturday",
+];
+
+const BASE_WORDS = [
+        "today",
+        "yesterday",
+        "tomorrow",
+        ...WEEKDAYS,
 ];
 
 const MONTHS = [


### PR DESCRIPTION
## Summary
- define `WEEKDAYS` before `BASE_WORDS`
- build `BASE_WORDS` via spread to avoid repeating the same weekdays
- regenerate compiled JavaScript

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6841bb8eea2c83268cf5f13a4bbe909f