### PR TITLE
Fix packaging for split settings file

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc && cp dist/*.js ./",
     "test": "npm run build && node test/test.js",
-    "zip": "npm run build && zip -r dynamic-dates-$npm_package_version.zip main.js plugin.js holidays.js suggest.js manifest.json README.md LICENSE",
+    "zip": "npm run build && zip -r dynamic-dates-$npm_package_version.zip main.js plugin.js settings.js holidays.js suggest.js manifest.json README.md LICENSE",
     "version": "node scripts/updateManifest.js"
   },
   "repository": {

--- a/test/test.js
+++ b/test/test.js
@@ -519,5 +519,16 @@
   assert.strictEqual(isHolidayQualifier('last thanksgiving'), true);
   assert.strictEqual(isHolidayQualifier('next random'), false);
 
+  /* ------------------------------------------------------------------ */
+  /* Packaging check                                                     */
+  /* ------------------------------------------------------------------ */
+  const child_process = require('child_process');
+  const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+  child_process.execSync('npm run zip', { stdio: 'ignore' });
+  const zipName = `dynamic-dates-${pkg.version}.zip`;
+  const zipList = child_process.execSync(`unzip -l ${zipName}`).toString();
+  assert.ok(zipList.includes('settings.js'), 'settings.js missing from zip');
+  fs.unlinkSync(zipName);
+
   console.log('All tests passed');
 })();


### PR DESCRIPTION
## Summary
- include `settings.js` in packaged zip
- verify zip contains `settings.js` in test suite

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6841c9cfdf7483268455eb1cca304604