### PR TITLE
Use chrono-node for parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,30 @@
     "": {
       "name": "dynamic-dates",
       "version": "1.0.0",
+      "dependencies": {
+        "chrono-node": "^2.8.2"
+      },
       "devDependencies": {
         "typescript": "^5.8.3"
       }
+    },
+    "node_modules/chrono-node": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.8.2.tgz",
+      "integrity": "sha512-7BJ6TRHs4sFtOSsTISWXGKjg7C70wD+NU+44uA6euGnbvZnECvgzUv+5TS9sICta2sBQWej4UYy8XAg4W9E7rQ==",
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.10.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.8.3",

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
   "author": "Matthew Gromer",
   "devDependencies": {
     "typescript": "^5.8.3"
+  },
+  "dependencies": {
+    "chrono-node": "^2.8.2"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import {
 // Settings
 
 import { DDSettings, DEFAULT_SETTINGS } from "./settings";
+import * as chrono from "chrono-node";
 
 // Phrase helpers
 
@@ -454,6 +455,25 @@ type PhraseToMomentFunc = {
         holidayOverrides: Record<string, boolean>;
 };
 
+function parseChronoPhrase(text: string, now: moment.Moment): moment.Moment | null {
+        const ref: Date = (now as any).toDate ? (now as any).toDate() : (now as any).d || new Date();
+        const base = chrono.en.parseDate(text, ref);
+        if (!base) return null;
+        let date = base;
+        const lower = text.toLowerCase();
+        const refDate: Date = ref;
+        const hasYear = /\b\d{2,4}\b/.test(text);
+        if (date < refDate && !/(last|ago|previous)/.test(lower) && !hasYear) {
+                const fwd = chrono.en.parseDate(text, refDate, { forwardDate: true });
+                if (fwd) date = fwd;
+        }
+        let m = moment(date);
+        if (!hasYear && !/(last|next|ago|previous)/.test(lower)) {
+                m = closestDate(m, now);
+        }
+        return m;
+}
+
 function phraseToMoment(phrase: string): moment.Moment | null {
         const now = moment();
         const lower = normalizeWeekdayAliases(phrase.toLowerCase().trim());
@@ -506,46 +526,7 @@ function phraseToMoment(phrase: string): moment.Moment | null {
                 }
         }
 
-        if (lower === "today") return now;
-        if (lower === "yesterday") return now.clone().subtract(1, "day");
-        if (lower === "tomorrow") return now.clone().add(1, "day");
-
-        const rel = lower.match(/^in (\d+) (day|days|week|weeks)$/);
-        if (rel) {
-                const n = parseInt(rel[1]);
-                if (!isNaN(n)) return now.clone().add(n * (rel[2].startsWith('week') ? 7 : 1), "day");
-        }
-        const ago = lower.match(/^(\d+) (day|days|week|weeks) ago$/);
-        if (ago) {
-                const n = parseInt(ago[1]);
-                if (!isNaN(n)) return now.clone().subtract(n * (ago[2].startsWith('week') ? 7 : 1), "day");
-        }
-
-        const mdy = lower.match(/^(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+(\d{1,2})(?:st|nd|rd|th)?(?:,)?\s*(\d{2,4})$/i);
-        if (mdy) {
-                let monthName = expandMonthName(mdy[1]);
-                const dayNum = parseInt(mdy[2]);
-                let yearNum = parseInt(mdy[3]);
-                if (!isNaN(dayNum) && !isNaN(yearNum)) {
-                        if (yearNum < 100) yearNum += 2000;
-                        const idx = MONTHS.indexOf(monthName.toLowerCase());
-                        const target = moment(new Date(yearNum, idx, dayNum));
-                        if (!target.isValid()) return null;
-                        return target;
-                }
-        }
-
-        const lastMd = lower.match(/^last\s+(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+(\d{1,2}\w*)$/i);
-        if (lastMd) {
-                let monthName = expandMonthName(lastMd[1]);
-                const dayNum = parseInt(lastMd[2]);
-                if (!isNaN(dayNum)) {
-                        const target = now.clone().month(monthName).date(dayNum);
-                        if (!target.isValid()) return null;
-                        if (!target.isBefore(now, "day")) target.subtract(1, "year");
-                        return target;
-                }
-        }
+        if (/\b(?:last|next)\s+(?:today|yesterday|tomorrow)\b/.test(lower)) return null;
 
         const justDay = lower.match(/^(?:the\s+)?(\d{1,2})(?:st|nd|rd|th)?$/);
         if (justDay) {
@@ -563,7 +544,7 @@ function phraseToMoment(phrase: string): moment.Moment | null {
         if (beforeWd) return phraseToMoment(`last ${beforeWd[1]}`);
 
         const nthWd = lower.match(/^(?:the\s+)?(first|second|third|fourth|fifth|last)\s+(sunday|monday|tuesday|wednesday|thursday|friday|saturday)\s+(?:in|of)\s+(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)(?:\s+(\d{2,4}))?/i);
-        if (nthWd) {
+                if (nthWd) {
                 const order = nthWd[1];
                 const wd = WEEKDAYS.indexOf(nthWd[2]);
                 const monthName = expandMonthName(nthWd[3]);
@@ -599,36 +580,28 @@ function phraseToMoment(phrase: string): moment.Moment | null {
                 return target;
         }
 
+        const chronoDate = parseChronoPhrase(phrase, now);
+        if (chronoDate) return chronoDate;
+
         const weekdays = WEEKDAYS;
 
         for (let i = 0; i < 7; i++) {
                 const name = weekdays[i];
 
-		if (lower === name) {
-			const diff = (i - now.weekday() + 7) % 7;
-			return now.clone().add(diff, "day");
-		}
-		if (lower === `next ${name}`) {
-			const diff = (i - now.weekday() + 7) % 7 || 7;
-			return now.clone().add(diff, "day");
-		}
+                if (lower === name) {
+                        const diff = (i - now.weekday() + 7) % 7;
+                        return now.clone().add(diff, "day");
+                }
+                if (lower === `next ${name}`) {
+                        const diff = (i - now.weekday() + 7) % 7 || 7;
+                        return now.clone().add(diff, "day");
+                }
                 if (lower === `last ${name}`) {
                         const diff = (now.weekday() - i + 7) % 7 || 7;
                         return now.clone().subtract(diff, "day");
                 }
         }
 
-        // Month + day (e.g., "august 20" or "aug 20th")
-        const md = lower.match(/^(jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\s+(\d{1,2}\w*)$/i);
-        if (md) {
-                let monthName = expandMonthName(md[1]);
-                const dayNum = parseInt(md[2]);
-                if (!isNaN(dayNum)) {
-                        const target = now.clone().month(monthName).date(dayNum);
-                        if (!target.isValid()) return null;
-                        return closestDate(target, now);
-                }
-        }
         return null;
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -14,11 +14,11 @@
   const settingsSrc = settingsCode.match(/exports\.DEFAULT_SETTINGS\s*=\s*{[^]*?};/);
   if (!settingsSrc) throw new Error('DEFAULT_SETTINGS not found');
   const settingsCodeAdjusted = settingsSrc[0].replace('exports.DEFAULT_SETTINGS', 'this.DEFAULT_SETTINGS');
-  const helpersSrc = code.match(/function nthWeekdayOfMonth[^]*?function needsYearAlias[^]*?function isHolidayQualifier[^]*?function formatTypedPhrase[^]*?\nconst PHRASES/);
+  const helpersSrc = code.match(/function nthWeekdayOfMonth[^]*?function needsYearAlias[^]*?function isHolidayQualifier[^]*?function formatTypedPhrase[^]*?function parseChronoPhrase[^]*?\nfunction phraseToMoment/);
   if (!helpersSrc) throw new Error('helper functions not found');
   const helpersCode = helpersSrc[0]
     .replace(/const DEFAULT_SETTINGS[^]*?};/, '')
-    .replace(/\nconst PHRASES[^]*/, '');
+    .replace(/\nfunction phraseToMoment[^]*/, '');
 
   /* ------------------------------------------------------------------ */
   /* Minimal runtime stubs                                              */
@@ -107,7 +107,8 @@
     Setting,
     normalizePath: p => p.replace(/\\/g, '/')
   };
-  const context = { moment, WEEKDAYS, MONTHS, BASE_WORDS, EditorSuggest, KeyboardEvent, Plugin, PluginSettingTab, Setting, obsidian_1 };
+  const chrono = require('chrono-node');
+  const context = { moment, WEEKDAYS, MONTHS, BASE_WORDS, EditorSuggest, KeyboardEvent, Plugin, PluginSettingTab, Setting, obsidian_1, chrono };
   vm.createContext(context);
   vm.runInContext('this.MONTH_ABBR = this.MONTHS.map(m => m.slice(0,3));', context);
   vm.runInContext('this.expandMonthName = function(name){ const idx = this.MONTH_ABBR.indexOf(name.slice(0,3).toLowerCase()); return idx >= 0 ? this.MONTHS[idx] : name; };', context);


### PR DESCRIPTION
## Summary
- add chrono-node dependency
- leverage chrono-node in `phraseToMoment`
- adjust helper extraction in tests and include chrono context

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6841f937299083268d2d547ca1004be6