### PR TITLE
Fix plugin default export

### DIFF
--- a/main.js
+++ b/main.js
@@ -1156,3 +1156,8 @@ class DDSettingTab extends obsidian_1.PluginSettingTab {
         });
     }
 }
+// Ensure CommonJS compatibility when loaded without transpiler
+if (typeof module !== "undefined") {
+    module.exports = DynamicDates;
+    module.exports.default = DynamicDates;
+}

--- a/plugin.js
+++ b/plugin.js
@@ -295,6 +295,8 @@ class DynamicDates extends obsidian_1.Plugin {
     }
 }
 exports.default = DynamicDates;
+module.exports = DynamicDates;
+module.exports.default = DynamicDates;
 /** UI for the plugin settings displayed in Obsidian's settings pane. */
 class DDSettingTab extends obsidian_1.PluginSettingTab {
     plugin;

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,8 @@ import {
         TFile,
 } from "obsidian";
 
+declare const module: any;
+
 // Settings
 
 interface DDSettings {
@@ -1303,3 +1305,10 @@ class DDSettingTab extends PluginSettingTab {
 
         }
 }
+
+// Ensure CommonJS compatibility when loaded without transpiler
+if (typeof module !== "undefined") {
+  (module as any).exports = DynamicDates;
+  (module as any).exports.default = DynamicDates;
+}
+


### PR DESCRIPTION
## Summary
- attach plugin class to `module.exports` for CommonJS environments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68483515070c83269a83c52662e01e31