### PR TITLE
Fix plugin export for compatibility

### DIFF
--- a/main.js
+++ b/main.js
@@ -1157,7 +1157,7 @@ class DDSettingTab extends obsidian_1.PluginSettingTab {
     }
 }
 // Ensure CommonJS compatibility when loaded without transpiler
-if (typeof module !== "undefined") {
+if (typeof module !== "undefined" && typeof module.exports !== "undefined") {
     module.exports = DynamicDates;
     module.exports.default = DynamicDates;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1307,7 +1307,7 @@ class DDSettingTab extends PluginSettingTab {
 }
 
 // Ensure CommonJS compatibility when loaded without transpiler
-if (typeof module !== "undefined") {
+if (typeof module !== "undefined" && typeof (module as any).exports !== "undefined") {
   (module as any).exports = DynamicDates;
   (module as any).exports.default = DynamicDates;
 }


### PR DESCRIPTION
## Summary
- ensure `DynamicDates` is exported when `module.exports` exists

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_684839b64cc4832689e0817a655d87e5