### PR TITLE
Fix fenced block detection

### DIFF
--- a/main.js
+++ b/main.js
@@ -586,9 +586,9 @@ class DDSuggest extends obsidian_1.EditorSuggest {
         // Skip suggestions inside code or wiki links
         // inside fenced block?
         let fenced = false;
-        const WINDOW = 20;
-        const startLine = Math.max(0, cursor.line - WINDOW);
-        for (let i = startLine; i <= cursor.line; i++) {
+        // Scan from the top of the file so we only toggle state when
+        // encountering actual opening/closing fences before the cursor
+        for (let i = 0; i <= cursor.line; i++) {
             let line = editor.getLine(i);
             if (i === cursor.line)
                 line = line.slice(0, cursor.ch);

--- a/src/main.ts
+++ b/src/main.ts
@@ -682,9 +682,9 @@ class DDSuggest extends EditorSuggest<string> {
                // Skip suggestions inside code or wiki links
                // inside fenced block?
                let fenced = false;
-               const WINDOW = 20;
-               const startLine = Math.max(0, cursor.line - WINDOW);
-               for (let i = startLine; i <= cursor.line; i++) {
+               // Scan from the top of the file so we only toggle state when
+               // encountering actual opening/closing fences before the cursor
+               for (let i = 0; i <= cursor.line; i++) {
                        let line = editor.getLine(i);
                        if (i === cursor.line) line = line.slice(0, cursor.ch);
                        let idx = 0;

--- a/suggest.js
+++ b/suggest.js
@@ -18,9 +18,8 @@ class DDSuggest extends obsidian_1.EditorSuggest {
         // Skip suggestions inside code or wiki links
         // inside fenced block?
         let fenced = false;
-        const WINDOW = 20;
-        const startLine = Math.max(0, cursor.line - WINDOW);
-        for (let i = startLine; i <= cursor.line; i++) {
+        // Scan from the top of the file to find unmatched fences
+        for (let i = 0; i <= cursor.line; i++) {
             let line = editor.getLine(i);
             if (i === cursor.line)
                 line = line.slice(0, cursor.ch);


### PR DESCRIPTION
## Summary
- correctly detect fenced code by scanning all lines before cursor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684891cdaf008326bfffffad8f7d7ae9