### PR TITLE
Add shorthand date aliases

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,8 +4,12 @@ const obsidian_1 = require("obsidian");
 // Phrase helpers
 const BASE_WORDS = [
     "today",
+    "tdy",
     "yesterday",
+    "yday",
     "tomorrow",
+    "tmr",
+    "tmrw",
     "monday",
     "tuesday",
     "wednesday",
@@ -58,11 +62,10 @@ function weekdayOnOrBefore(year, month, day, weekday) {
     return target.subtract(diff, "day");
 }
 function dayDiff(a, b) {
-    const ma = a;
-    if (typeof ma.diff === "function")
-        return Math.abs(ma.diff(b, "day"));
-    const da = ma.d || ma.toDate();
-    const db = b.d || b.toDate();
+    if (typeof a.diff === "function")
+        return Math.abs(a.diff(b, "day"));
+    const da = a.d || a.toDate?.() || new Date(NaN);
+    const db = b.d || b.toDate?.() || new Date(NaN);
     return Math.abs(Math.round((da.getTime() - db.getTime()) / 86400000));
 }
 function closestDate(base, now) {
@@ -90,9 +93,13 @@ const WEEKDAY_ALIAS = {
     thurs: "thursday",
     fri: "friday",
     sat: "saturday",
+    tmr: "tomorrow",
+    tmrw: "tomorrow",
+    tdy: "today",
+    yday: "yesterday",
 };
 function normalizeWeekdayAliases(str) {
-    return str.replace(/\b(?:sun|mon|tues?|wed(?:s)?|thu(?:rs)?|thur|fri|sat)\b/g, (m) => WEEKDAY_ALIAS[m] || m);
+    return str.replace(/\b(?:sun|mon|tues?|wed(?:s)?|thu(?:rs)?|thur|fri|sat|tmrw?|tdy|yday)\b/g, (m) => WEEKDAY_ALIAS[m] || m);
 }
 function islamicDateInYear(gYear, iMonth, iDay) {
     const fmt = new Intl.DateTimeFormat("en-u-ca-islamic", {
@@ -774,7 +781,7 @@ class DynamicDates extends obsidian_1.Plugin {
     prefixIndex = DynamicDates.makeNode();
     /** Cache of phrase -> moment keyed by phrase+date */
     dateCache = new Map();
-    constructor(app, manifest) {
+    constructor(app = {}, manifest = { id: "", name: "", version: "" }) {
         super(app, manifest);
         this.refreshPhrasesCache();
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,8 +40,12 @@ interface PluginManifest {
 
 const BASE_WORDS = [
         "today",
+        "tdy",
         "yesterday",
+        "yday",
         "tomorrow",
+        "tmr",
+        "tmrw",
         "monday",
         "tuesday",
         "wednesday",
@@ -140,10 +144,14 @@ const WEEKDAY_ALIAS: Record<string, string> = {
         thurs: "thursday",
         fri: "friday",
         sat: "saturday",
+        tmr: "tomorrow",
+        tmrw: "tomorrow",
+        tdy: "today",
+        yday: "yesterday",
 };
 
 function normalizeWeekdayAliases(str: string): string {
-        return str.replace(/\b(?:sun|mon|tues?|wed(?:s)?|thu(?:rs)?|thur|fri|sat)\b/g, (m) => WEEKDAY_ALIAS[m] || m);
+        return str.replace(/\b(?:sun|mon|tues?|wed(?:s)?|thu(?:rs)?|thur|fri|sat|tmrw?|tdy|yday)\b/g, (m) => WEEKDAY_ALIAS[m] || m);
 }
 
 function islamicDateInYear(gYear: number, iMonth: number, iDay: number): moment.Moment {

--- a/test/test.js
+++ b/test/test.js
@@ -94,7 +94,10 @@
   }
 
   const WEEKDAYS = ['sunday','monday','tuesday','wednesday','thursday','friday','saturday'];
-  const BASE_WORDS = ['today','yesterday','tomorrow', ...WEEKDAYS];
+  const BASE_WORDS = [
+    'today','tdy','yesterday','yday','tomorrow','tmr','tmrw',
+    ...WEEKDAYS
+  ];
 
   const obsidian_1 = {
     moment,
@@ -142,6 +145,10 @@
   assert.strictEqual(fmt(phraseToMoment('today')), '2024-05-08');
   assert.strictEqual(fmt(phraseToMoment('yesterday')), '2024-05-07');
   assert.strictEqual(fmt(phraseToMoment('tomorrow')), '2024-05-09');
+  assert.strictEqual(fmt(phraseToMoment('tdy')), '2024-05-08');
+  assert.strictEqual(fmt(phraseToMoment('yday')), '2024-05-07');
+  assert.strictEqual(fmt(phraseToMoment('tmr')), '2024-05-09');
+  assert.strictEqual(fmt(phraseToMoment('tmrw')), '2024-05-09');
   assert.strictEqual(fmt(phraseToMoment('next Monday')), '2024-05-13');
   assert.strictEqual(fmt(phraseToMoment('last Friday')), '2024-05-03');
   assert.strictEqual(phraseToMoment('last today'), null);


### PR DESCRIPTION
## Summary
- support shorthand words like `tmr`, `tmrw`, `tdy` and `yday`
- normalize these shorthands before date lookup
- test the new aliases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68498b7f45b083268d1a274aaf334a7c